### PR TITLE
[WIP] Query integration for Frankenstein.

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -92,7 +92,7 @@ func Main() int {
 	var queryEngine *promql.Engine
 	if !cfg.retrievalOnly {
 		not = notifier.New(&cfg.notifier)
-		queryEngine = promql.NewEngine(memStorage, &cfg.queryEngine)
+		queryEngine = promql.NewEngine(memStorage, nil, &cfg.queryEngine)
 		reloadables = append(reloadables, not)
 	}
 

--- a/frankenstein/cmd/frankenstein/main.go
+++ b/frankenstein/cmd/frankenstein/main.go
@@ -19,9 +19,12 @@ import (
 	"time"
 
 	"github.com/prometheus/common/log"
+	"github.com/prometheus/common/route"
 
 	"github.com/prometheus/prometheus/frankenstein"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage/remote"
+	"github.com/prometheus/prometheus/web/api/v1"
 )
 
 func main() {
@@ -64,6 +67,25 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// TODO: REMOVE - this is just a proof-of-concept for querying back data
+	// from a local Prometheus server via
+	// PromQL->MergeQuerier->IngesterQuerier. The distributor is not in
+	// the picture yet.
+	ingesterQuerier, err := frankenstein.NewIngesterQuerier("http://localhost:9090/")
+	if err != nil {
+		log.Fatal(err)
+	}
+	querier := frankenstein.MergeQuerier{
+		Queriers: []frankenstein.Querier{ingesterQuerier},
+	}
+	engine := promql.NewEngine(nil, querier, nil)
+
+	api := v1.NewAPI(engine, nil)
+	router := route.New()
+	api.Register(router.WithPrefix("/api/v1"))
+	http.Handle("/", router)
+	// END OF SECTION TO REMOVE
 
 	http.Handle("/push", frankenstein.AppenderHandler(distributor))
 	http.ListenAndServe(listen, nil)

--- a/frankenstein/iterator.go
+++ b/frankenstein/iterator.go
@@ -1,0 +1,63 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frankenstein
+
+import (
+	"sort"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/storage/local"
+	"github.com/prometheus/prometheus/storage/metric"
+)
+
+// This is a struct and not just a renamed type because otherwise the Metric
+// field and Metric() methods would clash.
+type sampleStreamIterator struct {
+	ss *model.SampleStream
+}
+
+func (it sampleStreamIterator) Metric() model.Metric {
+	return it.ss.Metric
+}
+
+func (it sampleStreamIterator) ValueAtOrBeforeTime(ts model.Time) model.SamplePair {
+	// TODO: This is a naive inefficient approach - in reality, queries go mostly
+	// linearly through iterators, and we will want to make successive calls to
+	// this method more efficient by taking into account the last result index
+	// somehow (similarly to how it's done in Prometheus's
+	// memorySeriesIterators).
+	i := sort.Search(len(it.ss.Values), func(n int) bool {
+		return it.ss.Values[n].Timestamp.After(ts)
+	})
+	if i == 0 {
+		return local.ZeroSamplePair
+	}
+	return it.ss.Values[i]
+}
+
+func (it sampleStreamIterator) RangeValues(in metric.Interval) []model.SamplePair {
+	n := len(it.ss.Values)
+	start := sort.Search(n, func(i int) bool {
+		return !it.ss.Values[i].Timestamp.Before(in.OldestInclusive)
+	})
+	end := sort.Search(n, func(i int) bool {
+		return it.ss.Values[i].Timestamp.After(in.NewestInclusive)
+	})
+
+	if start == n {
+		return nil
+	}
+
+	return it.ss.Values[start:end]
+}

--- a/frankenstein/iterator.go
+++ b/frankenstein/iterator.go
@@ -43,7 +43,7 @@ func (it sampleStreamIterator) ValueAtOrBeforeTime(ts model.Time) model.SamplePa
 	if i == 0 {
 		return local.ZeroSamplePair
 	}
-	return it.ss.Values[i]
+	return it.ss.Values[i-1]
 }
 
 func (it sampleStreamIterator) RangeValues(in metric.Interval) []model.SamplePair {

--- a/frankenstein/querier.go
+++ b/frankenstein/querier.go
@@ -1,0 +1,205 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frankenstein
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/prometheus/client_golang/api/prometheus"
+	"github.com/prometheus/common/model"
+	"golang.org/x/net/context"
+
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/storage/metric"
+)
+
+// A Querier allows querying all samples in a given time range that match a set
+// of label matchers.
+type Querier interface {
+	Query(from, to model.Time, matchers ...*metric.LabelMatcher) (model.Matrix, error)
+}
+
+// An IngesterQuerier is a Querier that fetches recent samples from a
+// Frankenstein Ingester.
+type IngesterQuerier struct {
+	api prometheus.QueryAPI
+}
+
+// NewIngesterQuerier creates a new IngesterQuerier given an ingester URL.
+// TODO: Make query timeout configurable.
+func NewIngesterQuerier(url string) (*IngesterQuerier, error) {
+	client, err := prometheus.New(prometheus.Config{
+		Address: url,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &IngesterQuerier{
+		api: prometheus.NewQueryAPI(client),
+	}, nil
+}
+
+// Query implements Querier.
+func (q *IngesterQuerier) Query(from, to model.Time, matchers ...*metric.LabelMatcher) (model.Matrix, error) {
+	// Create a PromQL query from the label matchers.
+	strs := make([]string, 0, len(matchers))
+	for _, m := range matchers {
+		strs = append(strs, m.String())
+	}
+	// TODO: Is LabelMatcher.String() sufficiently escaped?
+	expr := fmt.Sprintf("{%s}[%ds]", strings.Join(strs, ","), int64(to.Sub(from).Seconds()))
+
+	// Query the remote ingester.
+	res, err := q.api.Query(context.Background(), expr, to.Time())
+	if err != nil {
+		return nil, err
+	}
+
+	// Munge response data into a model.Matrix if necessary.
+	switch res.Type() {
+	case model.ValMatrix:
+		return res.(model.Matrix), nil
+	case model.ValVector:
+		v := res.(model.Vector)
+		m := make(model.Matrix, 0, len(v))
+		for _, s := range v {
+			m = append(m, &model.SampleStream{
+				Metric: s.Metric,
+				Values: []model.SamplePair{
+					{
+						Value:     s.Value,
+						Timestamp: s.Timestamp,
+					},
+				},
+			})
+		}
+		return m, nil
+	default:
+		panic("unexpected response value type")
+	}
+}
+
+// A ChunkQuerier is a Querier that fetches samples from a ChunkStore.
+type ChunkQuerier struct {
+	store ChunkStore
+}
+
+// NewChunkQuerier creates a new ChunkQuerier given a ChunkStore.
+func NewChunkQuerier(store ChunkStore) *ChunkQuerier {
+	return &ChunkQuerier{
+		store: store,
+	}
+}
+
+// Query implements Querier and transforms a list of chunks into sample
+// matrices.
+func (q *ChunkQuerier) Query(from, to model.Time, matchers ...*metric.LabelMatcher) (model.Matrix, error) {
+	// Get chunks for all matching series from ChunkStore.
+	chunks, err := q.store.Get(from, to, matchers...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Group chunks by series, sort and dedupe samples.
+	sampleStreams := map[model.Fingerprint]*model.SampleStream{}
+
+	for _, c := range chunks {
+		fp := c.Metric.Fingerprint()
+		ss, ok := sampleStreams[fp]
+		if !ok {
+			ss = &model.SampleStream{
+				Metric: c.Metric,
+			}
+			sampleStreams[fp] = ss
+		}
+		ss.Values = append(ss.Values, decodeChunk(c)...)
+	}
+
+	for _, ss := range sampleStreams {
+		sort.Sort(timeSortableSamplePairs(ss.Values))
+		// TODO: should we also dedupe samples here or leave that to the upper layers?
+	}
+
+	matrix := make(model.Matrix, 0, len(sampleStreams))
+	for _, ss := range sampleStreams {
+		matrix = append(matrix, ss)
+	}
+
+	return matrix, nil
+}
+
+type timeSortableSamplePairs []model.SamplePair
+
+func (ts timeSortableSamplePairs) Len() int {
+	return len(ts)
+}
+
+func (ts timeSortableSamplePairs) Less(i, j int) bool {
+	return ts[i].Timestamp < ts[j].Timestamp
+}
+
+func (ts timeSortableSamplePairs) Swap(i, j int) {
+	ts[i], ts[j] = ts[j], ts[i]
+}
+
+func decodeChunk(c Chunk) []model.SamplePair {
+	// TODO: Implement chunk decoding (this function is just a placeholder, this
+	// code will live somewhere else anyways). The chunking format is not defined
+	// yet, so it depends on how the write path will encode them.
+	return nil
+}
+
+// A MergeQuerier is a promql.Querier that merges the results of multiple
+// frankenstein.Queriers for the same query.
+type MergeQuerier struct {
+	queriers []Querier
+}
+
+// Query fetches series for a given time range and label matchers from multiple
+// promql.Queriers and returns the merged results as a map of series iterators.
+func (qm MergeQuerier) Query(from, to model.Time, matchers ...*metric.LabelMatcher) (map[model.Fingerprint]promql.SeriesIterator, error) {
+	iterators := map[model.Fingerprint]promql.SeriesIterator{}
+
+	// Fetch samples from all queriers and group them by fingerprint (unsorted
+	// and with overlap).
+	for _, q := range qm.queriers {
+		matrix, err := q.Query(from, to, matchers...)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, ss := range matrix {
+			fp := ss.Metric.Fingerprint()
+			if it, ok := iterators[fp]; !ok {
+				iterators[fp] = sampleStreamIterator{
+					ss: ss,
+				}
+			} else {
+				ssIt := it.(sampleStreamIterator)
+				ssIt.ss.Values = append(ssIt.ss.Values, ss.Values...)
+			}
+		}
+	}
+
+	// Sort and dedupe samples.
+	for _, it := range iterators {
+		sortable := timeSortableSamplePairs(it.(sampleStreamIterator).ss.Values)
+		sort.Sort(sortable)
+		// TODO: Dedupe samples. Not strictly necessary.
+	}
+
+	return iterators, nil
+}

--- a/frankenstein/querier.go
+++ b/frankenstein/querier.go
@@ -165,7 +165,7 @@ func decodeChunk(c Chunk) []model.SamplePair {
 // A MergeQuerier is a promql.Querier that merges the results of multiple
 // frankenstein.Queriers for the same query.
 type MergeQuerier struct {
-	queriers []Querier
+	Queriers []Querier
 }
 
 // Query fetches series for a given time range and label matchers from multiple
@@ -175,7 +175,7 @@ func (qm MergeQuerier) Query(from, to model.Time, matchers ...*metric.LabelMatch
 
 	// Fetch samples from all queriers and group them by fingerprint (unsorted
 	// and with overlap).
-	for _, q := range qm.queriers {
+	for _, q := range qm.Queriers {
 		matrix, err := q.Query(from, to, matchers...)
 		if err != nil {
 			return nil, err

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestQueryConcurrency(t *testing.T) {
-	engine := NewEngine(nil, nil)
+	engine := NewEngine(nil, nil, nil)
 	defer engine.Stop()
 
 	block := make(chan struct{})
@@ -72,7 +72,7 @@ func TestQueryConcurrency(t *testing.T) {
 }
 
 func TestQueryTimeout(t *testing.T) {
-	engine := NewEngine(nil, &EngineOptions{
+	engine := NewEngine(nil, nil, &EngineOptions{
 		Timeout:              5 * time.Millisecond,
 		MaxConcurrentQueries: 20,
 	})
@@ -93,7 +93,7 @@ func TestQueryTimeout(t *testing.T) {
 }
 
 func TestQueryCancel(t *testing.T) {
-	engine := NewEngine(nil, nil)
+	engine := NewEngine(nil, nil, nil)
 	defer engine.Stop()
 
 	// Cancel a running query before it completes.
@@ -138,7 +138,7 @@ func TestQueryCancel(t *testing.T) {
 }
 
 func TestEngineShutdown(t *testing.T) {
-	engine := NewEngine(nil, nil)
+	engine := NewEngine(nil, nil, nil)
 
 	block := make(chan struct{})
 	processing := make(chan struct{})

--- a/promql/preloader.go
+++ b/promql/preloader.go
@@ -1,0 +1,57 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/storage/metric"
+)
+
+func preloadQuery(querier Querier, expr Expr, from, to model.Time) error {
+	var queryErr error
+	Inspect(expr, func(node Node) bool {
+		switch n := node.(type) {
+		case *VectorSelector:
+			iterators, err := querier.Query(
+				from.Add(-n.Offset-StalenessDelta),
+				to.Add(-n.Offset),
+				n.LabelMatchers...,
+			)
+			if err != nil {
+				queryErr = err
+				return false
+			}
+			for fp, it := range iterators {
+				n.iterators[fp] = it
+				n.metrics[fp] = metric.Metric{Metric: it.Metric()}
+			}
+		case *MatrixSelector:
+			iterators, err := querier.Query(
+				from.Add(-n.Offset-n.Range),
+				to.Add(-n.Offset),
+				n.LabelMatchers...,
+			)
+			if err != nil {
+				queryErr = err
+				return false
+			}
+			for fp, it := range iterators {
+				n.iterators[fp] = it
+				n.metrics[fp] = metric.Metric{Metric: it.Metric()}
+			}
+		}
+		return true
+	})
+	return queryErr
+}

--- a/promql/preloader.go
+++ b/promql/preloader.go
@@ -15,6 +15,7 @@ package promql
 
 import (
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/storage/local"
 	"github.com/prometheus/prometheus/storage/metric"
 )
 
@@ -32,6 +33,8 @@ func preloadQuery(querier Querier, expr Expr, from, to model.Time) error {
 				queryErr = err
 				return false
 			}
+			n.iterators = map[model.Fingerprint]local.SeriesIterator{}
+			n.metrics = map[model.Fingerprint]metric.Metric{}
 			for fp, it := range iterators {
 				n.iterators[fp] = it
 				n.metrics[fp] = metric.Metric{Metric: it.Metric()}
@@ -46,6 +49,8 @@ func preloadQuery(querier Querier, expr Expr, from, to model.Time) error {
 				queryErr = err
 				return false
 			}
+			n.iterators = map[model.Fingerprint]local.SeriesIterator{}
+			n.metrics = map[model.Fingerprint]metric.Metric{}
 			for fp, it := range iterators {
 				n.iterators[fp] = it
 				n.metrics[fp] = metric.Metric{Metric: it.Metric()}

--- a/promql/querier.go
+++ b/promql/querier.go
@@ -1,0 +1,34 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/prometheus/storage/local"
+	"github.com/prometheus/prometheus/storage/metric"
+)
+
+// A SeriesIterator combines a local.SeriesIterator together with the metric
+// that corresponds to the iterator.
+type SeriesIterator interface {
+	local.SeriesIterator
+	Metric() model.Metric
+}
+
+// A Querier provides a map of series iterators given a time range and label
+// matchers.
+type Querier interface {
+	Query(from, to model.Time, matchers ...*metric.LabelMatcher) (map[model.Fingerprint]SeriesIterator, error)
+}

--- a/promql/test.go
+++ b/promql/test.go
@@ -498,7 +498,7 @@ func (t *Test) clear() {
 	t.storage, closer = local.NewTestStorage(t, 2)
 
 	t.closeStorage = closer.Close
-	t.queryEngine = NewEngine(t.storage, nil)
+	t.queryEngine = NewEngine(t.storage, nil, nil)
 }
 
 // Close closes resources associated with the Test.

--- a/rules/recording_test.go
+++ b/rules/recording_test.go
@@ -26,7 +26,7 @@ import (
 func TestRuleEval(t *testing.T) {
 	storage, closer := local.NewTestStorage(t, 2)
 	defer closer.Close()
-	engine := promql.NewEngine(storage, nil)
+	engine := promql.NewEngine(storage, nil, nil)
 	now := model.Now()
 
 	suite := []struct {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -205,7 +205,7 @@ func TestTemplateExpansion(t *testing.T) {
 	})
 	storage.WaitForIndexing()
 
-	engine := promql.NewEngine(storage, nil)
+	engine := promql.NewEngine(storage, nil, nil)
 
 	for i, s := range scenarios {
 		var result string

--- a/vendor/github.com/prometheus/client_golang/api/prometheus/api.go
+++ b/vendor/github.com/prometheus/client_golang/api/prometheus/api.go
@@ -1,0 +1,341 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package prometheus provides bindings to the Prometheus HTTP API:
+// http://prometheus.io/docs/querying/api/
+package prometheus
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"golang.org/x/net/context"
+	"golang.org/x/net/context/ctxhttp"
+)
+
+const (
+	statusAPIError = 422
+	apiPrefix      = "/api/v1"
+
+	epQuery       = "/query"
+	epQueryRange  = "/query_range"
+	epLabelValues = "/label/:name/values"
+	epSeries      = "/series"
+)
+
+type ErrorType string
+
+const (
+	// The different API error types.
+	ErrBadData     ErrorType = "bad_data"
+	ErrTimeout               = "timeout"
+	ErrCanceled              = "canceled"
+	ErrExec                  = "execution"
+	ErrBadResponse           = "bad_response"
+)
+
+// Error is an error returned by the API.
+type Error struct {
+	Type ErrorType
+	Msg  string
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("%s: %s", e.Type, e.Msg)
+}
+
+// CancelableTransport is like net.Transport but provides
+// per-request cancelation functionality.
+type CancelableTransport interface {
+	http.RoundTripper
+	CancelRequest(req *http.Request)
+}
+
+var DefaultTransport CancelableTransport = &http.Transport{
+	Proxy: http.ProxyFromEnvironment,
+	Dial: (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}).Dial,
+	TLSHandshakeTimeout: 10 * time.Second,
+}
+
+// Config defines configuration parameters for a new client.
+type Config struct {
+	// The address of the Prometheus to connect to.
+	Address string
+
+	// Transport is used by the Client to drive HTTP requests. If not
+	// provided, DefaultTransport will be used.
+	Transport CancelableTransport
+}
+
+func (cfg *Config) transport() CancelableTransport {
+	if cfg.Transport == nil {
+		return DefaultTransport
+	}
+	return cfg.Transport
+}
+
+type Client interface {
+	url(ep string, args map[string]string) *url.URL
+	do(context.Context, *http.Request) (*http.Response, []byte, error)
+}
+
+// New returns a new Client.
+func New(cfg Config) (Client, error) {
+	u, err := url.Parse(cfg.Address)
+	if err != nil {
+		return nil, err
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + apiPrefix
+
+	return &httpClient{
+		endpoint:  u,
+		transport: cfg.transport(),
+	}, nil
+}
+
+type httpClient struct {
+	endpoint  *url.URL
+	transport CancelableTransport
+}
+
+func (c *httpClient) url(ep string, args map[string]string) *url.URL {
+	p := path.Join(c.endpoint.Path, ep)
+
+	for arg, val := range args {
+		arg = ":" + arg
+		p = strings.Replace(p, arg, val, -1)
+	}
+
+	u := *c.endpoint
+	u.Path = p
+
+	return &u
+}
+
+func (c *httpClient) do(ctx context.Context, req *http.Request) (*http.Response, []byte, error) {
+	resp, err := ctxhttp.Do(ctx, &http.Client{Transport: c.transport}, req)
+
+	defer func() {
+		if resp != nil {
+			resp.Body.Close()
+		}
+	}()
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var body []byte
+	done := make(chan struct{})
+	go func() {
+		body, err = ioutil.ReadAll(resp.Body)
+		close(done)
+	}()
+
+	select {
+	case <-ctx.Done():
+		err = resp.Body.Close()
+		<-done
+		if err == nil {
+			err = ctx.Err()
+		}
+	case <-done:
+	}
+
+	return resp, body, err
+}
+
+// apiClient wraps a regular client and processes successful API responses.
+// Successful also includes responses that errored at the API level.
+type apiClient struct {
+	Client
+}
+
+type apiResponse struct {
+	Status    string          `json:"status"`
+	Data      json.RawMessage `json:"data"`
+	ErrorType ErrorType       `json:"errorType"`
+	Error     string          `json:"error"`
+}
+
+func (c apiClient) do(ctx context.Context, req *http.Request) (*http.Response, []byte, error) {
+	resp, body, err := c.Client.do(ctx, req)
+	if err != nil {
+		return resp, body, err
+	}
+
+	code := resp.StatusCode
+
+	if code/100 != 2 && code != statusAPIError {
+		return resp, body, &Error{
+			Type: ErrBadResponse,
+			Msg:  fmt.Sprintf("bad response code %d", resp.StatusCode),
+		}
+	}
+
+	var result apiResponse
+
+	if err = json.Unmarshal(body, &result); err != nil {
+		return resp, body, &Error{
+			Type: ErrBadResponse,
+			Msg:  err.Error(),
+		}
+	}
+
+	if (code == statusAPIError) != (result.Status == "error") {
+		err = &Error{
+			Type: ErrBadResponse,
+			Msg:  "inconsistent body for response code",
+		}
+	}
+
+	if code == statusAPIError && result.Status == "error" {
+		err = &Error{
+			Type: result.ErrorType,
+			Msg:  result.Error,
+		}
+	}
+
+	return resp, []byte(result.Data), err
+}
+
+// Range represents a sliced time range.
+type Range struct {
+	// The boundaries of the time range.
+	Start, End time.Time
+	// The maximum time between two slices within the boundaries.
+	Step time.Duration
+}
+
+// queryResult contains result data for a query.
+type queryResult struct {
+	Type   model.ValueType `json:"resultType"`
+	Result interface{}     `json:"result"`
+
+	// The decoded value.
+	v model.Value
+}
+
+func (qr *queryResult) UnmarshalJSON(b []byte) error {
+	v := struct {
+		Type   model.ValueType `json:"resultType"`
+		Result json.RawMessage `json:"result"`
+	}{}
+
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	switch v.Type {
+	case model.ValScalar:
+		var sv model.Scalar
+		err = json.Unmarshal(v.Result, &sv)
+		qr.v = &sv
+
+	case model.ValVector:
+		var vv model.Vector
+		err = json.Unmarshal(v.Result, &vv)
+		qr.v = vv
+
+	case model.ValMatrix:
+		var mv model.Matrix
+		err = json.Unmarshal(v.Result, &mv)
+		qr.v = mv
+
+	default:
+		err = fmt.Errorf("unexpected value type %q", v.Type)
+	}
+	return err
+}
+
+// QueryAPI provides bindings the Prometheus's query API.
+type QueryAPI interface {
+	// Query performs a query for the given time.
+	Query(ctx context.Context, query string, ts time.Time) (model.Value, error)
+	// Query performs a query for the given range.
+	QueryRange(ctx context.Context, query string, r Range) (model.Value, error)
+}
+
+// NewQueryAPI returns a new QueryAPI for the client.
+func NewQueryAPI(c Client) QueryAPI {
+	return &httpQueryAPI{client: apiClient{c}}
+}
+
+type httpQueryAPI struct {
+	client Client
+}
+
+func (h *httpQueryAPI) Query(ctx context.Context, query string, ts time.Time) (model.Value, error) {
+	u := h.client.url(epQuery, nil)
+	q := u.Query()
+
+	q.Set("query", query)
+	q.Set("time", ts.Format(time.RFC3339Nano))
+
+	u.RawQuery = q.Encode()
+
+	req, _ := http.NewRequest("GET", u.String(), nil)
+
+	_, body, err := h.client.do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var qres queryResult
+	err = json.Unmarshal(body, &qres)
+
+	return model.Value(qres.v), err
+}
+
+func (h *httpQueryAPI) QueryRange(ctx context.Context, query string, r Range) (model.Value, error) {
+	u := h.client.url(epQueryRange, nil)
+	q := u.Query()
+
+	var (
+		start = r.Start.Format(time.RFC3339Nano)
+		end   = r.End.Format(time.RFC3339Nano)
+		step  = strconv.FormatFloat(r.Step.Seconds(), 'f', 3, 64)
+	)
+
+	q.Set("query", query)
+	q.Set("start", start)
+	q.Set("end", end)
+	q.Set("step", step)
+
+	u.RawQuery = q.Encode()
+
+	req, _ := http.NewRequest("GET", u.String(), nil)
+
+	_, body, err := h.client.do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var qres queryResult
+	err = json.Unmarshal(body, &qres)
+
+	return model.Value(qres.v), err
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -235,6 +235,11 @@
 			"revisionTime": "2015-09-05T08:12:15+01:00"
 		},
 		{
+			"path": "github.com/prometheus/client_golang/api/prometheus",
+			"revision": "9f1ed1ed4a5f754c9b626e5cf8ec1ea7d622e017",
+			"revisionTime": "2016-06-27T15:36:20+01:00"
+		},
+		{
 			"path": "github.com/prometheus/client_golang/prometheus",
 			"revision": "449ccefff16c8e2b7229f6be1921ba22f62461fe",
 			"revisionTime": "2015-10-26T02:27:06+01:00"


### PR DESCRIPTION
@tomwilkie This is still lacking chunk decoding and some top-level things that tie everything together. However, it would be good to check if the overall approach is an ok starting point before adding tests and more.

Basically, the `promql.Engine` has been modified to take either an old-style storage (`local.Querier`) or frankenstein-style querier (`promql.Querier`), and it uses whatever it's there. That way the rest of Prometheus still compiles. This is of course just a prototype solution. Ultimately, it would be good to unify the queryer interface.

The `promql.Querier` implementation that the Engine is going to use is a `frankenstein.MergeQuerier` in this case, which calls multiple `frankenstein.Queriers` for the same query and merges the results and returns iterators for all series. Although both `promql.Querier` and `frankenstein.Querier` are named `x.Querier`, they have slightly different return values (series iterators vs. full value matrix).

Nothing is tested yet, so there may be egregious bugs that I'll find later during testing.
