### PR TITLE
Fix number of expected chunk lookup channel replies.

### DIFF
--- a/frankenstein/chunk_store.go
+++ b/frankenstein/chunk_store.go
@@ -253,7 +253,7 @@ func (c *AWSChunkStore) lookupChunks(from, through model.Time, matchers []*metri
 
 	chunkSets := []Chunk{}
 	errors := []error{}
-	for i := 0; i < len(buckets)*len(matchers); i++ {
+	for i := 0; i < len(buckets); i++ {
 		select {
 		case chunkSet := <-incomingChunkSets:
 			chunkSets = append(chunkSets, chunkSet...)


### PR DESCRIPTION
Since the chunk lookups are no longer parallel between matchers, we only expect one reply for each bucket now.
