### PR TITLE
End-to-end AWS proof of concept

### DIFF
--- a/frankenstein/grafana-config/dashboard.json
+++ b/frankenstein/grafana-config/dashboard.json
@@ -1,0 +1,136 @@
+{
+  "dashboard": {
+    "id": null,
+    "title": "Test dashboard",
+    "tags": [],
+    "style": "dark",
+    "timezone": "browser",
+    "editable": true,
+    "hideControls": false,
+    "sharedCrosshair": false,
+    "rows": [
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "Prometheus",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 1,
+            "isNew": true,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 2,
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "testmetric",
+                "intervalFactor": 2,
+                "refId": "A",
+                "step": 2
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Panel Title",
+            "tooltip": {
+              "msResolution": true,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "show": true
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "title": "Row"
+      }
+    ],
+    "time": {
+      "from": "now-5m",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "templating": {
+      "list": []
+    },
+    "annotations": {
+      "list": []
+    },
+    "schemaVersion": 12,
+    "version": 0,
+    "links": [],
+    "gnetId": null
+  }
+}

--- a/frankenstein/grafana-config/datasource.json
+++ b/frankenstein/grafana-config/datasource.json
@@ -1,0 +1,7 @@
+{
+  "name": "Prometheus",
+  "type": "prometheus",
+  "url": "http://localhost:9094",
+  "access": "direct",
+  "basicAuth": false
+}

--- a/storage/local/frank_helpers.go
+++ b/storage/local/frank_helpers.go
@@ -1,0 +1,48 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package local
+
+import (
+	"github.com/prometheus/common/model"
+)
+
+func DecodeDoubleDeltaChunk(buf []byte) []model.SamplePair {
+	c := newDoubleDeltaEncodedChunk(d1, d0, true, chunkLen)
+	c.unmarshalFromBuf(buf)
+	it := c.newIterator()
+	samples := make([]model.SamplePair, 0, c.len())
+	for it.scan() {
+		samples = append(samples, it.value())
+	}
+	return samples
+}
+
+func EncodeDoubleDeltaChunk(samples []model.SamplePair) []byte {
+	c := newDoubleDeltaEncodedChunk(d1, d0, true, chunkLen)
+	for _, s := range samples {
+		chunks, err := c.add(s)
+		if err != nil {
+			panic(err)
+		}
+		if len(chunks) != 1 {
+			panic("too many samples for one chunk")
+		}
+		c = chunks[0].(*doubleDeltaEncodedChunk)
+	}
+	buf := make([]byte, chunkLen)
+	if err := c.marshalToBuf(buf); err != nil {
+		panic(err)
+	}
+	return buf
+}


### PR DESCRIPTION
This writes some test chunks to the Dockerized S3/DynamoDB, sets up a full query pipeline to be able to query them back, and also adds a Grafana container with datasource+dashboard to view the written data at: http://localhost:3000/dashboard/db/test-dashboard

Right now, everything is in the main `frank` binary, but obviously that's just for the POC.
