### PR TITLE
[WIP] Add POC Distributor->Ingestor HTTP query API.

### DIFF
--- a/frankenstein/cmd/frankenstein/main.go
+++ b/frankenstein/cmd/frankenstein/main.go
@@ -135,8 +135,7 @@ func setupDistributor(
 	// TODO: Move querier to separate binary.
 	querier := frankenstein.MergeQuerier{
 		Queriers: []frankenstein.Querier{
-			// TODO: Re-add Distributor. The new ingestor cannot be queried yet, so
-			// this would currently throw an error.
+			distributor,
 			&frankenstein.ChunkQuerier{
 				Store: chunkStore,
 			},
@@ -169,6 +168,7 @@ func setupIngestor(consulClient frankenstein.ConsulClient, consulPrefix string, 
 	}
 	prometheus.MustRegister(ingestor)
 	http.Handle("/push", frankenstein.AppenderHandler(ingestor))
+	http.Handle("/api/v1/query_raw", frankenstein.QueryHandler(ingestor))
 }
 
 func writeIngestorConfigToConsul(consulClient frankenstein.ConsulClient, consulPrefix string) error {

--- a/frankenstein/query_api_helpers.go
+++ b/frankenstein/query_api_helpers.go
@@ -1,0 +1,117 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frankenstein
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/prometheus/common/model"
+)
+
+type status string
+
+const (
+	statusSuccess status = "success"
+	statusError          = "error"
+)
+
+type errorType string
+
+const (
+	errorNone     errorType = ""
+	errorTimeout            = "timeout"
+	errorCanceled           = "canceled"
+	errorExec               = "execution"
+	errorBadData            = "bad_data"
+)
+
+type apiError struct {
+	typ errorType
+	err error
+}
+
+func (e *apiError) Error() string {
+	return fmt.Sprintf("%s: %s", e.typ, e.err)
+}
+
+type response struct {
+	Status    status      `json:"status"`
+	Data      interface{} `json:"data,omitempty"`
+	ErrorType errorType   `json:"errorType,omitempty"`
+	Error     string      `json:"error,omitempty"`
+}
+
+type apiFunc func(r *http.Request) (interface{}, *apiError)
+
+type queryData struct {
+	ResultType model.ValueType `json:"resultType"`
+	Result     model.Value     `json:"result"`
+}
+
+func respond(w http.ResponseWriter, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	b, err := json.Marshal(&response{
+		Status: statusSuccess,
+		Data:   data,
+	})
+	if err != nil {
+		return
+	}
+	w.Write(b)
+}
+
+func respondError(w http.ResponseWriter, apiErr *apiError, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var code int
+	switch apiErr.typ {
+	case errorBadData:
+		code = http.StatusBadRequest
+	case errorExec:
+		code = 422
+	case errorCanceled, errorTimeout:
+		code = http.StatusServiceUnavailable
+	default:
+		code = http.StatusInternalServerError
+	}
+	w.WriteHeader(code)
+
+	b, err := json.Marshal(&response{
+		Status:    statusError,
+		ErrorType: apiErr.typ,
+		Error:     apiErr.err.Error(),
+		Data:      data,
+	})
+	if err != nil {
+		return
+	}
+	w.Write(b)
+}
+
+func parseTime(s string) (model.Time, error) {
+	if t, err := strconv.ParseFloat(s, 64); err == nil {
+		ts := int64(t * float64(time.Second))
+		return model.TimeFromUnixNano(ts), nil
+	}
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return model.TimeFromUnixNano(t.UnixNano()), nil
+	}
+	return 0, fmt.Errorf("cannot parse %q to a valid timestamp", s)
+}


### PR DESCRIPTION
I want to attempt to add an official /api/v1/query_raw endpoint to
Prometheus, so for now this is lifting code from the Prometheus API and
clientlib in an improvised way for now:
- vendored HTTP API client library was changed in place to allow
  raw queries
- private helper types from Prometheus's HTTP API were copied over for
  implementing the raw query endpoint.

Obviously, this can only be temporary. The first wart would go away if
we get the raw query interface into Prometheus and then modify the
actual clientlib to look like the modified vendored version here. For
the second point, we'll have to restructure the API-serving code in
Prometheus in such a way that it's possible to only reuse the raw query
part of it.
