### PR TITLE
Make chunk timeouts less ridiculously tiny

### DIFF
--- a/storage/local/frankenstein.go
+++ b/storage/local/frankenstein.go
@@ -17,8 +17,8 @@ import (
 )
 
 const (
-	flushCheckPeriod = 5 * time.Second
-	maxChunkAge      = 30 * time.Second
+	flushCheckPeriod = 1 * time.Minute
+	maxChunkAge      = 10 * time.Minute
 )
 
 // Ingestor deals with "in flight" chunks.


### PR DESCRIPTION
If we want to start looking at performance, we probably don't want to
write out one chunk for every 30s of samples for each series.
