### PR TITLE
Add query multitenancy and fix some bugs

### DIFF
--- a/cmd/prometheus/config.go
+++ b/cmd/prometheus/config.go
@@ -218,6 +218,16 @@ func init() {
 		&cfg.remote.GenericURL, "storage.remote.generic-url", "",
 		"The URL of the generic remote server to send samples to. None, if empty.",
 	)
+	cfg.fs.StringVar(
+		// TODO: Figure out best way to allow specifying headers, if we want that.
+		&cfg.remote.GenericHeaderName, "storage.remote.generic-header-name", "",
+		"The name of an HTTP header to send with every request to the generic remote server.",
+	)
+	cfg.fs.StringVar(
+		// TODO: Figure out best way to allow specifying headers, if we want that.
+		&cfg.remote.GenericHeaderValue, "storage.remote.generic-header-value", "",
+		"The value of an HTTP header to send with every request to the generic remote server.",
+	)
 	cfg.fs.DurationVar(
 		&cfg.remote.StorageTimeout, "storage.remote.timeout", 30*time.Second,
 		"The timeout to use when sending samples to the remote storage.",

--- a/frankenstein/api/api.go
+++ b/frankenstein/api/api.go
@@ -1,0 +1,363 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/route"
+	"golang.org/x/net/context"
+
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/storage/local"
+	"github.com/prometheus/prometheus/storage/metric"
+	"github.com/prometheus/prometheus/util/httputil"
+)
+
+type status string
+
+const (
+	statusSuccess status = "success"
+	statusError          = "error"
+)
+
+type errorType string
+
+const (
+	errorNone     errorType = ""
+	errorTimeout            = "timeout"
+	errorCanceled           = "canceled"
+	errorExec               = "execution"
+	errorBadData            = "bad_data"
+)
+
+var corsHeaders = map[string]string{
+	"Access-Control-Allow-Headers":  "Accept, Authorization, Content-Type, Origin",
+	"Access-Control-Allow-Methods":  "GET, OPTIONS",
+	"Access-Control-Allow-Origin":   "*",
+	"Access-Control-Expose-Headers": "Date",
+}
+
+type apiError struct {
+	typ errorType
+	err error
+}
+
+func (e *apiError) Error() string {
+	return fmt.Sprintf("%s: %s", e.typ, e.err)
+}
+
+type response struct {
+	Status    status      `json:"status"`
+	Data      interface{} `json:"data,omitempty"`
+	ErrorType errorType   `json:"errorType,omitempty"`
+	Error     string      `json:"error,omitempty"`
+}
+
+// Enables cross-site script calls.
+func setCORS(w http.ResponseWriter) {
+	for h, v := range corsHeaders {
+		w.Header().Set(h, v)
+	}
+}
+
+type apiFunc func(ctx context.Context, r *http.Request) (interface{}, *apiError)
+
+// API can register a set of endpoints in a router and handle
+// them using the provided storage and query engine.
+type API struct {
+	newQuerier func(ctx context.Context) local.Querier
+
+	context func(r *http.Request) context.Context
+	now     func() model.Time
+}
+
+// New returns an initialized API type.
+func New(newQuerier func(ctx context.Context) local.Querier) *API {
+	return &API{
+		newQuerier: newQuerier,
+		context:    route.Context,
+		now:        model.Now,
+	}
+}
+
+// Register the API's endpoints in the given router.
+func (api *API) Register(r *route.Router) {
+	instr := func(name string, f apiFunc) http.HandlerFunc {
+		hf := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// TODO: Get user ID from header again once we have a proxy in front of
+			// Frankenstein that creates the header:
+			//
+			// userID := r.Header.Get(userIDHeaderName)
+			//
+			// For now, getting the user ID from basic auth allows for easy testing
+			// with Grafana.
+			userID, _, _ := r.BasicAuth()
+			if r.Method != "OPTIONS" && userID == "" {
+				respondError(w, &apiError{errorBadData, fmt.Errorf("missing user ID")}, nil)
+				return
+			}
+			ctx := context.WithValue(context.Background(), local.UserIDContextKey, userID) // TODO: replace string with constant
+			setCORS(w)
+
+			if data, err := f(ctx, r); err != nil {
+				respondError(w, err, data)
+			} else if data != nil {
+				respond(w, data)
+			} else {
+				w.WriteHeader(http.StatusNoContent)
+			}
+		})
+		return prometheus.InstrumentHandler(name, httputil.CompressionHandler{
+			Handler: hf,
+		})
+	}
+
+	r.Options("/*path", instr("options", api.options))
+
+	r.Get("/query", instr("query", api.query))
+	r.Get("/query_range", instr("query_range", api.queryRange))
+
+	r.Get("/label/:name/values", instr("label_values", api.labelValues))
+
+	r.Get("/series", instr("series", api.series))
+	r.Del("/series", instr("drop_series", api.dropSeries))
+}
+
+type queryData struct {
+	ResultType model.ValueType `json:"resultType"`
+	Result     model.Value     `json:"result"`
+}
+
+func (api *API) options(_ context.Context, r *http.Request) (interface{}, *apiError) {
+	return nil, nil
+}
+
+func (api *API) query(ctx context.Context, r *http.Request) (interface{}, *apiError) {
+	var ts model.Time
+	if t := r.FormValue("time"); t != "" {
+		var err error
+		ts, err = parseTime(t)
+		if err != nil {
+			return nil, &apiError{errorBadData, err}
+		}
+	} else {
+		ts = api.now()
+	}
+
+	qry, err := api.newEngine(ctx).NewInstantQuery(r.FormValue("query"), ts)
+	if err != nil {
+		return nil, &apiError{errorBadData, err}
+	}
+
+	res := qry.Exec()
+	if res.Err != nil {
+		switch res.Err.(type) {
+		case promql.ErrQueryCanceled:
+			return nil, &apiError{errorCanceled, res.Err}
+		case promql.ErrQueryTimeout:
+			return nil, &apiError{errorTimeout, res.Err}
+		}
+		return nil, &apiError{errorExec, res.Err}
+	}
+	return &queryData{
+		ResultType: res.Value.Type(),
+		Result:     res.Value,
+	}, nil
+}
+
+func (api *API) queryRange(ctx context.Context, r *http.Request) (interface{}, *apiError) {
+	start, err := parseTime(r.FormValue("start"))
+	if err != nil {
+		return nil, &apiError{errorBadData, err}
+	}
+	end, err := parseTime(r.FormValue("end"))
+	if err != nil {
+		return nil, &apiError{errorBadData, err}
+	}
+	step, err := parseDuration(r.FormValue("step"))
+	if err != nil {
+		return nil, &apiError{errorBadData, err}
+	}
+
+	// For safety, limit the number of returned points per timeseries.
+	// This is sufficient for 60s resolution for a week or 1h resolution for a year.
+	if end.Sub(start)/step > 11000 {
+		err := errors.New("exceeded maximum resolution of 11,000 points per timeseries. Try decreasing the query resolution (?step=XX)")
+		return nil, &apiError{errorBadData, err}
+	}
+
+	qry, err := api.newEngine(ctx).NewRangeQuery(r.FormValue("query"), start, end, step)
+	if err != nil {
+		return nil, &apiError{errorBadData, err}
+	}
+
+	res := qry.Exec()
+	if res.Err != nil {
+		switch res.Err.(type) {
+		case promql.ErrQueryCanceled:
+			return nil, &apiError{errorCanceled, res.Err}
+		case promql.ErrQueryTimeout:
+			return nil, &apiError{errorTimeout, res.Err}
+		}
+		return nil, &apiError{errorExec, res.Err}
+	}
+	return &queryData{
+		ResultType: res.Value.Type(),
+		Result:     res.Value,
+	}, nil
+}
+
+func (api *API) labelValues(ctx context.Context, r *http.Request) (interface{}, *apiError) {
+	name := route.Param(api.context(r), "name")
+
+	if !model.LabelNameRE.MatchString(name) {
+		return nil, &apiError{errorBadData, fmt.Errorf("invalid label name: %q", name)}
+	}
+	vals, err := api.newQuerier(ctx).LabelValuesForLabelName(model.LabelName(name))
+	if err != nil {
+		return nil, &apiError{errorExec, err}
+	}
+	sort.Sort(vals)
+
+	return vals, nil
+}
+
+func (api *API) series(ctx context.Context, r *http.Request) (interface{}, *apiError) {
+	r.ParseForm()
+	if len(r.Form["match[]"]) == 0 {
+		return nil, &apiError{errorBadData, fmt.Errorf("no match[] parameter provided")}
+	}
+
+	var start model.Time
+	if t := r.FormValue("start"); t != "" {
+		var err error
+		start, err = parseTime(t)
+		if err != nil {
+			return nil, &apiError{errorBadData, err}
+		}
+	} else {
+		start = model.Earliest
+	}
+
+	var end model.Time
+	if t := r.FormValue("end"); t != "" {
+		var err error
+		end, err = parseTime(t)
+		if err != nil {
+			return nil, &apiError{errorBadData, err}
+		}
+	} else {
+		end = model.Latest
+	}
+
+	var matcherSets []metric.LabelMatchers
+	for _, s := range r.Form["match[]"] {
+		matchers, err := promql.ParseMetricSelector(s)
+		if err != nil {
+			return nil, &apiError{errorBadData, err}
+		}
+		matcherSets = append(matcherSets, matchers)
+	}
+
+	res, err := api.newQuerier(ctx).MetricsForLabelMatchers(start, end, matcherSets...)
+	if err != nil {
+		return nil, &apiError{errorExec, err}
+	}
+
+	metrics := make([]model.Metric, 0, len(res))
+	for _, met := range res {
+		metrics = append(metrics, met.Metric)
+	}
+	return metrics, nil
+}
+
+func (api *API) dropSeries(ctx context.Context, r *http.Request) (interface{}, *apiError) {
+	return nil, &apiError{errorExec, fmt.Errorf("dropping series is not supported")}
+}
+
+func (api *API) newEngine(ctx context.Context) *promql.Engine {
+	return promql.NewEngine(api.newQuerier(ctx), nil)
+}
+
+func respond(w http.ResponseWriter, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	b, err := json.Marshal(&response{
+		Status: statusSuccess,
+		Data:   data,
+	})
+	if err != nil {
+		return
+	}
+	w.Write(b)
+}
+
+func respondError(w http.ResponseWriter, apiErr *apiError, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var code int
+	switch apiErr.typ {
+	case errorBadData:
+		code = http.StatusBadRequest
+	case errorExec:
+		code = 422
+	case errorCanceled, errorTimeout:
+		code = http.StatusServiceUnavailable
+	default:
+		code = http.StatusInternalServerError
+	}
+	w.WriteHeader(code)
+
+	b, err := json.Marshal(&response{
+		Status:    statusError,
+		ErrorType: apiErr.typ,
+		Error:     apiErr.err.Error(),
+		Data:      data,
+	})
+	if err != nil {
+		return
+	}
+	w.Write(b)
+}
+
+func parseTime(s string) (model.Time, error) {
+	if t, err := strconv.ParseFloat(s, 64); err == nil {
+		ts := int64(t * float64(time.Second))
+		return model.TimeFromUnixNano(ts), nil
+	}
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return model.TimeFromUnixNano(t.UnixNano()), nil
+	}
+	return 0, fmt.Errorf("cannot parse %q to a valid timestamp", s)
+}
+
+func parseDuration(s string) (time.Duration, error) {
+	if d, err := strconv.ParseFloat(s, 64); err == nil {
+		return time.Duration(d * float64(time.Second)), nil
+	}
+	if d, err := model.ParseDuration(s); err == nil {
+		return time.Duration(d), nil
+	}
+	return 0, fmt.Errorf("cannot parse %q to a valid duration", s)
+}

--- a/frankenstein/api/api_test.go
+++ b/frankenstein/api/api_test.go
@@ -1,0 +1,598 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/common/route"
+	"golang.org/x/net/context"
+
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/storage/local"
+)
+
+func TestEndpoints(t *testing.T) {
+	suite, err := promql.NewTest(t, promql.LocalStorage, `
+		load 1m
+			test_metric1{foo="bar"} 0+100x100
+			test_metric1{foo="boo"} 1+0x100
+			test_metric2{foo="boo"} 1+0x100
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer suite.Close()
+
+	if err := suite.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	now := model.Now()
+	api := &API{
+		newQuerier: func(ctx context.Context) local.Querier {
+			return suite.Storage()
+		},
+		now: func() model.Time { return now },
+	}
+
+	start := model.Time(0)
+	var tests = []struct {
+		endpoint apiFunc
+		params   map[string]string
+		query    url.Values
+		response interface{}
+		errType  errorType
+	}{
+		{
+			endpoint: api.query,
+			query: url.Values{
+				"query": []string{"2"},
+				"time":  []string{"123.3"},
+			},
+			response: &queryData{
+				ResultType: model.ValScalar,
+				Result: &model.Scalar{
+					Value:     2,
+					Timestamp: start.Add(123*time.Second + 300*time.Millisecond),
+				},
+			},
+		},
+		{
+			endpoint: api.query,
+			query: url.Values{
+				"query": []string{"0.333"},
+				"time":  []string{"1970-01-01T00:02:03Z"},
+			},
+			response: &queryData{
+				ResultType: model.ValScalar,
+				Result: &model.Scalar{
+					Value:     0.333,
+					Timestamp: start.Add(123 * time.Second),
+				},
+			},
+		},
+		{
+			endpoint: api.query,
+			query: url.Values{
+				"query": []string{"0.333"},
+				"time":  []string{"1970-01-01T01:02:03+01:00"},
+			},
+			response: &queryData{
+				ResultType: model.ValScalar,
+				Result: &model.Scalar{
+					Value:     0.333,
+					Timestamp: start.Add(123 * time.Second),
+				},
+			},
+		},
+		{
+			endpoint: api.query,
+			query: url.Values{
+				"query": []string{"0.333"},
+			},
+			response: &queryData{
+				ResultType: model.ValScalar,
+				Result: &model.Scalar{
+					Value:     0.333,
+					Timestamp: now,
+				},
+			},
+		},
+		{
+			endpoint: api.queryRange,
+			query: url.Values{
+				"query": []string{"time()"},
+				"start": []string{"0"},
+				"end":   []string{"2"},
+				"step":  []string{"1"},
+			},
+			response: &queryData{
+				ResultType: model.ValMatrix,
+				Result: model.Matrix{
+					&model.SampleStream{
+						Values: []model.SamplePair{
+							{Value: 0, Timestamp: start},
+							{Value: 1, Timestamp: start.Add(1 * time.Second)},
+							{Value: 2, Timestamp: start.Add(2 * time.Second)},
+						},
+						Metric: model.Metric{},
+					},
+				},
+			},
+		},
+		// Missing query params in range queries.
+		{
+			endpoint: api.queryRange,
+			query: url.Values{
+				"query": []string{"time()"},
+				"end":   []string{"2"},
+				"step":  []string{"1"},
+			},
+			errType: errorBadData,
+		},
+		{
+			endpoint: api.queryRange,
+			query: url.Values{
+				"query": []string{"time()"},
+				"start": []string{"0"},
+				"step":  []string{"1"},
+			},
+			errType: errorBadData,
+		},
+		{
+			endpoint: api.queryRange,
+			query: url.Values{
+				"query": []string{"time()"},
+				"start": []string{"0"},
+				"end":   []string{"2"},
+			},
+			errType: errorBadData,
+		},
+		// Bad query expression.
+		{
+			endpoint: api.query,
+			query: url.Values{
+				"query": []string{"invalid][query"},
+				"time":  []string{"1970-01-01T01:02:03+01:00"},
+			},
+			errType: errorBadData,
+		},
+		{
+			endpoint: api.queryRange,
+			query: url.Values{
+				"query": []string{"invalid][query"},
+				"start": []string{"0"},
+				"end":   []string{"100"},
+				"step":  []string{"1"},
+			},
+			errType: errorBadData,
+		},
+		{
+			endpoint: api.labelValues,
+			params: map[string]string{
+				"name": "__name__",
+			},
+			response: model.LabelValues{
+				"test_metric1",
+				"test_metric2",
+			},
+		},
+		{
+			endpoint: api.labelValues,
+			params: map[string]string{
+				"name": "foo",
+			},
+			response: model.LabelValues{
+				"bar",
+				"boo",
+			},
+		},
+		// Bad name parameter.
+		{
+			endpoint: api.labelValues,
+			params: map[string]string{
+				"name": "not!!!allowed",
+			},
+			errType: errorBadData,
+		},
+		{
+			endpoint: api.series,
+			query: url.Values{
+				"match[]": []string{`test_metric2`},
+			},
+			response: []model.Metric{
+				{
+					"__name__": "test_metric2",
+					"foo":      "boo",
+				},
+			},
+		},
+		{
+			endpoint: api.series,
+			query: url.Values{
+				"match[]": []string{`test_metric1{foo=~".+o"}`},
+			},
+			response: []model.Metric{
+				{
+					"__name__": "test_metric1",
+					"foo":      "boo",
+				},
+			},
+		},
+		{
+			endpoint: api.series,
+			query: url.Values{
+				"match[]": []string{`test_metric1{foo=~"o$"}`, `test_metric1{foo=~".+o"}`},
+			},
+			response: []model.Metric{
+				{
+					"__name__": "test_metric1",
+					"foo":      "boo",
+				},
+			},
+		},
+		{
+			endpoint: api.series,
+			query: url.Values{
+				"match[]": []string{`test_metric1{foo=~".+o"}`, `none`},
+			},
+			response: []model.Metric{
+				{
+					"__name__": "test_metric1",
+					"foo":      "boo",
+				},
+			},
+		},
+		// Start and end before series starts.
+		{
+			endpoint: api.series,
+			query: url.Values{
+				"match[]": []string{`test_metric2`},
+				"start":   []string{"-2"},
+				"end":     []string{"-1"},
+			},
+			response: []model.Metric{},
+		},
+		// Start and end after series ends.
+		{
+			endpoint: api.series,
+			query: url.Values{
+				"match[]": []string{`test_metric2`},
+				"start":   []string{"100000"},
+				"end":     []string{"100001"},
+			},
+			response: []model.Metric{},
+		},
+		// Start before series starts, end after series ends.
+		{
+			endpoint: api.series,
+			query: url.Values{
+				"match[]": []string{`test_metric2`},
+				"start":   []string{"-1"},
+				"end":     []string{"100000"},
+			},
+			response: []model.Metric{
+				{
+					"__name__": "test_metric2",
+					"foo":      "boo",
+				},
+			},
+		},
+		// Start and end within series.
+		{
+			endpoint: api.series,
+			query: url.Values{
+				"match[]": []string{`test_metric2`},
+				"start":   []string{"1"},
+				"end":     []string{"100"},
+			},
+			response: []model.Metric{
+				{
+					"__name__": "test_metric2",
+					"foo":      "boo",
+				},
+			},
+		},
+		// Start within series, end after.
+		{
+			endpoint: api.series,
+			query: url.Values{
+				"match[]": []string{`test_metric2`},
+				"start":   []string{"1"},
+				"end":     []string{"100000"},
+			},
+			response: []model.Metric{
+				{
+					"__name__": "test_metric2",
+					"foo":      "boo",
+				},
+			},
+		},
+		// Start before series, end within series.
+		{
+			endpoint: api.series,
+			query: url.Values{
+				"match[]": []string{`test_metric2`},
+				"start":   []string{"-1"},
+				"end":     []string{"1"},
+			},
+			response: []model.Metric{
+				{
+					"__name__": "test_metric2",
+					"foo":      "boo",
+				},
+			},
+		},
+		// Missing match[] query params in series requests.
+		{
+			endpoint: api.series,
+			errType:  errorBadData,
+		},
+		{
+			endpoint: api.dropSeries,
+			errType:  errorExec,
+		},
+	}
+
+	for _, test := range tests {
+		// Build a context with the correct request params.
+		ctx := context.WithValue(context.Background(), local.UserIDContextKey, "0")
+		for p, v := range test.params {
+			ctx = route.WithParam(ctx, p, v)
+		}
+		api.context = func(r *http.Request) context.Context {
+			return ctx
+		}
+
+		req, err := http.NewRequest("ANY", fmt.Sprintf("http://example.com?%s", test.query.Encode()), nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, apiErr := test.endpoint(ctx, req)
+		if apiErr != nil {
+			if test.errType == errorNone {
+				t.Fatalf("Unexpected error: %s", apiErr)
+			}
+			if test.errType != apiErr.typ {
+				t.Fatalf("Expected error of type %q but got type %q: %v", test.errType, apiErr.typ, apiErr.err)
+			}
+			continue
+		}
+		if apiErr == nil && test.errType != errorNone {
+			t.Fatalf("Expected error of type %q but got none", test.errType)
+		}
+		if !reflect.DeepEqual(resp, test.response) {
+			t.Fatalf("Response does not match, expected:\n%+v\ngot:\n%+v", test.response, resp)
+		}
+		// Ensure that removed metrics are unindexed before the next request.
+		suite.Storage().WaitForIndexing()
+	}
+}
+
+func TestRespondSuccess(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		respond(w, "test")
+	}))
+	defer s.Close()
+
+	resp, err := http.Get(s.URL)
+	if err != nil {
+		t.Fatalf("Error on test request: %s", err)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		t.Fatalf("Error reading response body: %s", err)
+	}
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("Return code %d expected in success response but got %d", 200, resp.StatusCode)
+	}
+	if h := resp.Header.Get("Content-Type"); h != "application/json" {
+		t.Fatalf("Expected Content-Type %q but got %q", "application/json", h)
+	}
+
+	var res response
+	if err = json.Unmarshal([]byte(body), &res); err != nil {
+		t.Fatalf("Error unmarshaling JSON body: %s", err)
+	}
+
+	exp := &response{
+		Status: statusSuccess,
+		Data:   "test",
+	}
+	if !reflect.DeepEqual(&res, exp) {
+		t.Fatalf("Expected response \n%v\n but got \n%v\n", res, exp)
+	}
+}
+
+func TestRespondError(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		respondError(w, &apiError{errorTimeout, errors.New("message")}, "test")
+	}))
+	defer s.Close()
+
+	resp, err := http.Get(s.URL)
+	if err != nil {
+		t.Fatalf("Error on test request: %s", err)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		t.Fatalf("Error reading response body: %s", err)
+	}
+
+	if want, have := http.StatusServiceUnavailable, resp.StatusCode; want != have {
+		t.Fatalf("Return code %d expected in error response but got %d", want, have)
+	}
+	if h := resp.Header.Get("Content-Type"); h != "application/json" {
+		t.Fatalf("Expected Content-Type %q but got %q", "application/json", h)
+	}
+
+	var res response
+	if err = json.Unmarshal([]byte(body), &res); err != nil {
+		t.Fatalf("Error unmarshaling JSON body: %s", err)
+	}
+
+	exp := &response{
+		Status:    statusError,
+		Data:      "test",
+		ErrorType: errorTimeout,
+		Error:     "message",
+	}
+	if !reflect.DeepEqual(&res, exp) {
+		t.Fatalf("Expected response \n%v\n but got \n%v\n", res, exp)
+	}
+}
+
+func TestParseTime(t *testing.T) {
+	ts, err := time.Parse(time.RFC3339Nano, "2015-06-03T13:21:58.555Z")
+	if err != nil {
+		panic(err)
+	}
+
+	var tests = []struct {
+		input  string
+		fail   bool
+		result time.Time
+	}{
+		{
+			input: "",
+			fail:  true,
+		}, {
+			input: "abc",
+			fail:  true,
+		}, {
+			input: "30s",
+			fail:  true,
+		}, {
+			input:  "123",
+			result: time.Unix(123, 0),
+		}, {
+			input:  "123.123",
+			result: time.Unix(123, 123000000),
+		}, {
+			input:  "123.123",
+			result: time.Unix(123, 123000000),
+		}, {
+			input:  "2015-06-03T13:21:58.555Z",
+			result: ts,
+		}, {
+			input:  "2015-06-03T14:21:58.555+01:00",
+			result: ts,
+		},
+	}
+
+	for _, test := range tests {
+		ts, err := parseTime(test.input)
+		if err != nil && !test.fail {
+			t.Errorf("Unexpected error for %q: %s", test.input, err)
+			continue
+		}
+		if err == nil && test.fail {
+			t.Errorf("Expected error for %q but got none", test.input)
+			continue
+		}
+		res := model.TimeFromUnixNano(test.result.UnixNano())
+		if !test.fail && ts != res {
+			t.Errorf("Expected time %v for input %q but got %v", res, test.input, ts)
+		}
+	}
+}
+
+func TestParseDuration(t *testing.T) {
+	var tests = []struct {
+		input  string
+		fail   bool
+		result time.Duration
+	}{
+		{
+			input: "",
+			fail:  true,
+		}, {
+			input: "abc",
+			fail:  true,
+		}, {
+			input: "2015-06-03T13:21:58.555Z",
+			fail:  true,
+		}, {
+			input:  "123",
+			result: 123 * time.Second,
+		}, {
+			input:  "123.333",
+			result: 123*time.Second + 333*time.Millisecond,
+		}, {
+			input:  "15s",
+			result: 15 * time.Second,
+		}, {
+			input:  "5m",
+			result: 5 * time.Minute,
+		},
+	}
+
+	for _, test := range tests {
+		d, err := parseDuration(test.input)
+		if err != nil && !test.fail {
+			t.Errorf("Unexpected error for %q: %s", test.input, err)
+			continue
+		}
+		if err == nil && test.fail {
+			t.Errorf("Expected error for %q but got none", test.input)
+			continue
+		}
+		if !test.fail && d != test.result {
+			t.Errorf("Expected duration %v for input %q but got %v", test.result, test.input, d)
+		}
+	}
+}
+
+func TestOptionsMethod(t *testing.T) {
+	r := route.New()
+	api := &API{}
+	api.Register(r)
+
+	s := httptest.NewServer(r)
+	defer s.Close()
+
+	req, err := http.NewRequest("OPTIONS", s.URL+"/any_path", nil)
+	if err != nil {
+		t.Fatalf("Error creating OPTIONS request: %s", err)
+	}
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Error executing OPTIONS request: %s", err)
+	}
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("Expected status %d, got %d", http.StatusNoContent, resp.StatusCode)
+	}
+
+	for h, v := range corsHeaders {
+		if resp.Header.Get(h) != v {
+			t.Fatalf("Expected %q for header %q, got %q", v, h, resp.Header.Get(h))
+		}
+	}
+}

--- a/frankenstein/ingester_client.go
+++ b/frankenstein/ingester_client.go
@@ -83,8 +83,14 @@ func (c *IngesterClient) Append(ctx context.Context, samples []*model.Sample) er
 	}
 	httpReq.Header.Add(userIDHeaderName, userID)
 	httpReq.Header.Set("Content-Type", string(expfmt.FmtProtoDelim))
-	_, err = c.client.Do(httpReq)
-	return err
+	resp, err := c.client.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("error sending samples to ingester: %v", err)
+	}
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("sending samples to ingester failed with HTTP status %s", resp.Status)
+	}
+	return nil
 }
 
 // Query implements Querier.

--- a/frankenstein/querier.go
+++ b/frankenstein/querier.go
@@ -89,8 +89,8 @@ func (ts timeSortableSamplePairs) Swap(i, j int) {
 // A MergeQuerier is a promql.Querier that merges the results of multiple
 // frankenstein.Queriers for the same query.
 type MergeQuerier struct {
-	ctx      context.Context
 	Queriers []Querier
+	Context  context.Context
 }
 
 // QueryRange fetches series for a given time range and label matchers from multiple
@@ -101,7 +101,7 @@ func (qm MergeQuerier) QueryRange(from, to model.Time, matchers ...*metric.Label
 	// Fetch samples from all queriers and group them by fingerprint (unsorted
 	// and with overlap).
 	for _, q := range qm.Queriers {
-		matrix, err := q.Query(qm.ctx, from, to, matchers...)
+		matrix, err := q.Query(qm.Context, from, to, matchers...)
 		if err != nil {
 			return nil, err
 		}
@@ -140,4 +140,22 @@ func (qm MergeQuerier) QueryInstant(ts model.Time, stalenessDelta time.Duration,
 	// For now, just fall back to QueryRange, as QueryInstant is merely allows
 	// for instant-specific optimization.
 	return qm.QueryRange(ts.Add(-stalenessDelta), ts, matchers...)
+}
+
+// MetricsForLabelMatchers Implements local.Querier.
+func (qm MergeQuerier) MetricsForLabelMatchers(from, through model.Time, matcherSets ...metric.LabelMatchers) ([]metric.Metric, error) {
+	// TODO: Implement.
+	return nil, nil
+}
+
+// LastSampleForLabelMatchers implements local.Querier.
+func (qm MergeQuerier) LastSampleForLabelMatchers(cutoff model.Time, matcherSets ...metric.LabelMatchers) (model.Vector, error) {
+	// TODO: Implement.
+	return nil, nil
+}
+
+// LabelValuesForLabelName implements local.Querier.
+func (qm MergeQuerier) LabelValuesForLabelName(model.LabelName) (model.LabelValues, error) {
+	// TODO: Implement.
+	return nil, nil
 }

--- a/storage/local/frankenstein.go
+++ b/storage/local/frankenstein.go
@@ -235,7 +235,6 @@ func (i *Ingestor) Query(ctx context.Context, from, through model.Time, matchers
 	}
 
 	fps := state.index.lookup(matchers)
-	log.Infof("Query: should return %v", fps)
 
 	// fps is sorted, lock them in order to prevent deadlocks
 	queriedSamples := 0

--- a/storage/remote/generic/generic_test.go
+++ b/storage/remote/generic/generic_test.go
@@ -51,7 +51,7 @@ func TestMarshalStoreSamplesRequest(t *testing.T) {
 			Value:     1.23,
 		},
 	}
-	client := NewClient(server.URL, time.Second)
+	client := NewClient(server.URL, nil, time.Second)
 	if err := client.Store(samples); err != nil {
 		t.Fatalf("Error sending samples: %s", err)
 	}

--- a/storage/remote/remote.go
+++ b/storage/remote/remote.go
@@ -14,6 +14,7 @@
 package remote
 
 import (
+	"net/http"
 	"net/url"
 	"sync"
 	"time"
@@ -71,7 +72,11 @@ func New(o *Options) *Storage {
 		s.queues = append(s.queues, NewStorageQueueManager(c, 100*1024))
 	}
 	if o.GenericURL != "" {
-		c := generic.NewClient(o.GenericURL, o.StorageTimeout)
+		headers := http.Header{}
+		if o.GenericHeaderName != "" {
+			headers.Add(o.GenericHeaderName, o.GenericHeaderValue)
+		}
+		c := generic.NewClient(o.GenericURL, headers, o.StorageTimeout)
 		s.queues = append(s.queues, NewStorageQueueManager(c, 100*1024))
 	}
 	if len(s.queues) == 0 {
@@ -93,6 +98,8 @@ type Options struct {
 	GraphiteTransport       string
 	GraphitePrefix          string
 	GenericURL              string
+	GenericHeaderName       string
+	GenericHeaderValue      string
 }
 
 // Run starts the background processing of the storage queues.


### PR DESCRIPTION
This works for me end to end now. Since Grafana cannot set arbitrary
headers and we don't have an auth frontend in between Grafana and the
distributor yet, the distributor is temporarily taking the user ID from
basic auth. So to test with Grafana, edit the datasource and enable
basic auth with any user name (becomes userID) and password (is
ignored).

Switching around user IDs in basic auth in the data source seems to
indicate that it all works, end-to-end!
