### PR TITLE
Ignore collectors with no tokens

### DIFF
--- a/frankenstein/ring.go
+++ b/frankenstein/ring.go
@@ -79,7 +79,10 @@ func (r *Ring) GetAll() []Collector {
 
 	collectors := make([]Collector, 0, len(r.collectors))
 	for _, c := range r.collectors {
-		collectors = append(collectors, c)
+		// Ignore collectors with no tokens.
+		if len(c.Tokens) > 0 {
+			collectors = append(collectors, c)
+		}
 	}
 	return collectors
 }


### PR DESCRIPTION
We currently don't delete anything from consul, we just set the tokens to empty.  This should fix the error when fetching labels.
