### PR TITLE
Fix distributor -> ingester load balancing

### DIFF
--- a/frankenstein/consul_client.go
+++ b/frankenstein/consul_client.go
@@ -32,7 +32,7 @@ const (
 type ConsulClient interface {
 	Get(key string, out interface{}) error
 	CAS(key string, out interface{}, f CASCallback) error
-	WatchPrefix(prefix string, out interface{}, done chan struct{}, f func(string, interface{}) bool)
+	WatchPrefix(prefix string, factory func() interface{}, done chan struct{}, f func(string, interface{}) bool)
 	Put(p *consul.KVPair, q *consul.WriteOptions) (*consul.WriteMeta, error)
 }
 
@@ -148,7 +148,7 @@ func (c *consulClient) CAS(key string, out interface{}, f CASCallback) error {
 	return fmt.Errorf("failed to CAS %s", key)
 }
 
-func (c *consulClient) WatchPrefix(prefix string, out interface{}, done chan struct{}, f func(string, interface{}) bool) {
+func (c *consulClient) WatchPrefix(prefix string, factory func() interface{}, done chan struct{}, f func(string, interface{}) bool) {
 	const (
 		initialBackoff = 1 * time.Second
 		maxBackoff     = 1 * time.Minute
@@ -188,6 +188,7 @@ func (c *consulClient) WatchPrefix(prefix string, out interface{}, done chan str
 		index = meta.LastIndex
 
 		for _, kvp := range kvps {
+			out := factory()
 			if err := json.NewDecoder(bytes.NewReader(kvp.Value)).Decode(out); err != nil {
 				log.Errorf("Error deserialising %s: %v", kvp.Key, err)
 				continue

--- a/frankenstein/consul_client.go
+++ b/frankenstein/consul_client.go
@@ -148,6 +148,12 @@ func (c *consulClient) CAS(key string, out interface{}, f CASCallback) error {
 	return fmt.Errorf("failed to CAS %s", key)
 }
 
+// WatchPrefix will watch a given prefix in consul for changes.  When a value
+// under said prefix changes, the f callback is called with the deserialised
+// value. To construct the deserialised value, a factory function should be
+// supplied which generates an empy struct for WatchPrefix to deserialise into.
+// Values in Consul are asusmed to be JSON.  This function blocks until the
+// done channel is closed.
 func (c *consulClient) WatchPrefix(prefix string, factory func() interface{}, done chan struct{}, f func(string, interface{}) bool) {
 	const (
 		initialBackoff = 1 * time.Second

--- a/frankenstein/ring.go
+++ b/frankenstein/ring.go
@@ -17,77 +17,86 @@ package frankenstein
 
 import (
 	"errors"
+	"math"
 	"sort"
 	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
-type uint64s []uint64
+type uint32s []uint32
 
-func (x uint64s) Len() int           { return len(x) }
-func (x uint64s) Less(i, j int) bool { return x[i] < x[j] }
-func (x uint64s) Swap(i, j int)      { x[i], x[j] = x[j], x[i] }
+func (x uint32s) Len() int           { return len(x) }
+func (x uint32s) Less(i, j int) bool { return x[i] < x[j] }
+func (x uint32s) Swap(i, j int)      { x[i], x[j] = x[j], x[i] }
 
 // ErrEmptyRing is the error returned when trying to get an element when nothing has been added to hash.
 var ErrEmptyRing = errors.New("empty circle")
 
+var ingestorOwnershipDesc = prometheus.NewDesc(
+	"prometheus_distributor_ingester_ownership_percent",
+	"The percent ownership of the ring by ingestor",
+	[]string{"ingester"}, nil,
+)
+
 // Ring holds the information about the members of the consistent hash circle.
 type Ring struct {
 	mtx          sync.RWMutex
-	collectors   map[string]Collector // source of truth - indexed by key
-	circle       map[uint64]Collector // derived - indexed by token
-	sortedHashes uint64s              // derived
+	ingesters    map[string]IngesterDesc // source of truth - indexed by key
+	circle       map[uint32]IngesterDesc // derived - indexed by token
+	sortedHashes uint32s                 // derived
 }
 
 // NewRing creates a new Ring object.
 func NewRing() *Ring {
 	return &Ring{
-		circle:     map[uint64]Collector{},
-		collectors: map[string]Collector{},
+		circle:    map[uint32]IngesterDesc{},
+		ingesters: map[string]IngesterDesc{},
 	}
 }
 
 // Update inserts a collector in the consistent hash.
-func (r *Ring) Update(col Collector) {
+func (r *Ring) Update(col IngesterDesc) {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
-	r.collectors[col.ID] = col
+	r.ingesters[col.ID] = col
 	r.updateSortedHashes()
 }
 
-func (r *Ring) Delete(col Collector) {
+func (r *Ring) Delete(col IngesterDesc) {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
-	delete(r.collectors, col.ID)
+	delete(r.ingesters, col.ID)
 	r.updateSortedHashes()
 }
 
 // Get returns a collector close to the hash in the circle.
-func (r *Ring) Get(key uint64) (Collector, error) {
+func (r *Ring) Get(key uint32) (IngesterDesc, error) {
 	r.mtx.RLock()
 	defer r.mtx.RUnlock()
 	if len(r.circle) == 0 {
-		return Collector{}, ErrEmptyRing
+		return IngesterDesc{}, ErrEmptyRing
 	}
 	i := r.search(key)
 	return r.circle[r.sortedHashes[i]], nil
 }
 
-// GetAll returns all collectors in the circle.
-func (r *Ring) GetAll() []Collector {
+// GetAll returns all ingesters in the circle.
+func (r *Ring) GetAll() []IngesterDesc {
 	r.mtx.RLock()
 	defer r.mtx.RUnlock()
 
-	collectors := make([]Collector, 0, len(r.collectors))
-	for _, c := range r.collectors {
-		// Ignore collectors with no tokens.
+	ingesters := make([]IngesterDesc, 0, len(r.ingesters))
+	for _, c := range r.ingesters {
+		// Ignore ingesters with no tokens.
 		if len(c.Tokens) > 0 {
-			collectors = append(collectors, c)
+			ingesters = append(ingesters, c)
 		}
 	}
-	return collectors
+	return ingesters
 }
 
-func (r *Ring) search(key uint64) (i int) {
+func (r *Ring) search(key uint32) (i int) {
 	f := func(x int) bool {
 		return r.sortedHashes[x] > key
 	}
@@ -99,9 +108,9 @@ func (r *Ring) search(key uint64) (i int) {
 }
 
 func (r *Ring) updateSortedHashes() {
-	hashes := uint64s{}
-	circle := map[uint64]Collector{}
-	for _, col := range r.collectors {
+	hashes := uint32s{}
+	circle := map[uint32]IngesterDesc{}
+	for _, col := range r.ingesters {
 		hashes = append(hashes, col.Tokens...)
 		for _, token := range col.Tokens {
 			circle[token] = col
@@ -110,4 +119,36 @@ func (r *Ring) updateSortedHashes() {
 	sort.Sort(hashes)
 	r.sortedHashes = hashes
 	r.circle = circle
+}
+
+// Describe implements prometheus.Collector.
+func (r *Ring) Describe(ch chan<- *prometheus.Desc) {
+	ch <- ingestorOwnershipDesc
+}
+
+// Collect implements prometheus.Collector.
+func (r *Ring) Collect(ch chan<- prometheus.Metric) {
+	r.mtx.RLock()
+	defer r.mtx.RUnlock()
+
+	owned := map[string]uint32{}
+	for i, token := range r.sortedHashes {
+		var diff uint32
+		if i+1 == len(r.sortedHashes) {
+			diff = (math.MaxUint32 - token) + r.sortedHashes[0]
+		} else {
+			diff = r.sortedHashes[i+1] - token
+		}
+		collector := r.circle[token]
+		owned[collector.ID] = owned[collector.ID] + diff
+	}
+
+	for id, totalOwned := range owned {
+		ch <- prometheus.MustNewConstMetric(
+			ingestorOwnershipDesc,
+			prometheus.GaugeValue,
+			float64(totalOwned)/float64(math.MaxUint32),
+			id,
+		)
+	}
 }


### PR DESCRIPTION
A few changes
- Rename `Collector` type to `IngesterDesc`
- Make ingester tokens `uint32`s (so they can be generate by rand)
- Make the ingester pick 128 random tokens on startup
- Make the ConsulClient watch method take a factor function for making `IngesterDesc`s, to prevent iterations of the loop overwriting previous iterations values (this was causing all ingesters to have the same token).
- Add prom metric for % ownership of the ring by each ingester.
