### PR TITLE
Split memcache client into generic and Frank parts

### DIFF
--- a/frankenstein/chunk_cache.go
+++ b/frankenstein/chunk_cache.go
@@ -1,0 +1,142 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frankenstein
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/bradfitz/gomemcache/memcache"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/frankenstein/wire"
+)
+
+var (
+	memcacheRequests = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "prometheus",
+		Name:      "memcache_requests_total",
+		Help:      "Total count of chunks requested from memcache.",
+	})
+
+	memcacheHits = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "prometheus",
+		Name:      "memcache_hits_total",
+		Help:      "Total count of chunks found in memcache.",
+	})
+
+	memcacheRequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "prometheus",
+		Name:      "memcache_request_duration_seconds",
+		Help:      "Total time spent in seconds doing memcache requests.",
+		Buckets:   []float64{.001, .0025, .005, .01, .025, .05},
+	}, []string{"method", "status_code"})
+)
+
+func init() {
+	prometheus.MustRegister(memcacheRequests)
+	prometheus.MustRegister(memcacheHits)
+	prometheus.MustRegister(memcacheRequestDuration)
+}
+
+type Memcache interface {
+	GetMulti(keys []string) (map[string]*memcache.Item, error)
+	Set(item *memcache.Item) error
+}
+
+type ChunkCache struct {
+	Memcache   Memcache
+	Expiration time.Duration
+}
+
+func memcacheStatusCode(err error) string {
+	// See https://godoc.org/github.com/bradfitz/gomemcache/memcache#pkg-variables
+	switch err {
+	case nil:
+		return "200"
+	case memcache.ErrCacheMiss:
+		return "404"
+	case memcache.ErrMalformedKey:
+		return "400"
+	default:
+		return "500"
+	}
+}
+
+func memcacheKey(userID, chunkID string) string {
+	return fmt.Sprintf("%s/%s", userID, chunkID)
+}
+
+// FetchChunkData gets chunks from the chunk cache.
+func (c *ChunkCache) FetchChunkData(userID string, chunks []wire.Chunk) (found []wire.Chunk, missing []wire.Chunk, err error) {
+	memcacheRequests.Add(float64(len(chunks)))
+
+	keys := make([]string, 0, len(chunks))
+	for _, chunk := range chunks {
+		keys = append(keys, memcacheKey(userID, chunk.ID))
+	}
+
+	var items map[string]*memcache.Item
+	err = timeRequestMethodStatus("Get", memcacheRequestDuration, memcacheStatusCode, func() error {
+		var err error
+		items, err = c.Memcache.GetMulti(keys)
+		return err
+	})
+	if err != nil {
+		return nil, chunks, err
+	}
+
+	for _, chunk := range chunks {
+		item, ok := items[memcacheKey(userID, chunk.ID)]
+		if !ok {
+			missing = append(missing, chunk)
+		} else {
+			chunk.Data = item.Value
+			found = append(found, chunk)
+		}
+	}
+
+	memcacheHits.Add(float64(len(found)))
+	return found, missing, nil
+}
+
+// StoreChunkData serializes and stores a chunk in the chunk cache.
+func (c *ChunkCache) StoreChunkData(userID string, chunk *wire.Chunk) error {
+	return timeRequestMethodStatus("Put", memcacheRequestDuration, memcacheStatusCode, func() error {
+		// TODO: Add compression - maybe encapsulated in marshaling/unmarshaling
+		// methods of wire.Chunk.
+		item := memcache.Item{
+			Key:        memcacheKey(userID, chunk.ID),
+			Value:      chunk.Data,
+			Expiration: int32(c.Expiration.Seconds()),
+		}
+		return c.Memcache.Set(&item)
+	})
+}
+
+// StoreChunks serializes and stores multiple chunks in the chunk cache.
+func (c *ChunkCache) StoreChunks(userID string, chunks []wire.Chunk) error {
+	errs := make(chan error)
+	for _, chunk := range chunks {
+		go func(chunk *wire.Chunk) {
+			errs <- c.StoreChunkData(userID, chunk)
+		}(&chunk)
+	}
+	var errOut error
+	for i := 0; i < len(chunks); i++ {
+		if err := <-errs; err != nil {
+			errOut = err
+		}
+	}
+	return errOut
+}

--- a/frankenstein/chunk_store.go
+++ b/frankenstein/chunk_store.go
@@ -88,9 +88,9 @@ type ChunkStore interface {
 
 // ChunkStoreConfig specifies config for a ChunkStore
 type ChunkStoreConfig struct {
-	S3URL          string
-	DynamoDBURL    string
-	MemcacheClient *MemcacheClient
+	S3URL       string
+	DynamoDBURL string
+	ChunkCache  *ChunkCache
 }
 
 // NewAWSChunkStore makes a new ChunkStore
@@ -121,7 +121,7 @@ func NewAWSChunkStore(cfg ChunkStoreConfig) (*AWSChunkStore, error) {
 	return &AWSChunkStore{
 		dynamodb:   dynamodb.New(session.New(dynamoDBConfig)),
 		s3:         s3.New(session.New(s3Config)),
-		memcache:   cfg.MemcacheClient,
+		chunkCache: cfg.ChunkCache,
 		tableName:  tableName,
 		bucketName: bucketName,
 	}, nil
@@ -154,7 +154,7 @@ func userID(ctx context.Context) (string, error) {
 type AWSChunkStore struct {
 	dynamodb   dynamodbClient
 	s3         s3Client
-	memcache   *MemcacheClient
+	chunkCache *ChunkCache
 	tableName  string
 	bucketName string
 	cfg        ChunkStoreConfig
@@ -273,9 +273,9 @@ func (c *AWSChunkStore) Put(ctx context.Context, chunks []wire.Chunk) error {
 			return err
 		}
 
-		if c.memcache != nil {
-			if err = c.memcache.StoreChunkData(userID, &chunk); err != nil {
-				log.Warnf("Could not store %v in memcache: %v", chunk.ID, err)
+		if c.chunkCache != nil {
+			if err = c.chunkCache.StoreChunkData(userID, &chunk); err != nil {
+				log.Warnf("Could not store %v in chunk cache: %v", chunk.ID, err)
 			}
 		}
 	}
@@ -355,9 +355,9 @@ func (c *AWSChunkStore) Get(ctx context.Context, from, through model.Time, match
 		return nil, err
 	}
 
-	var fromMemcache []wire.Chunk
-	if c.memcache != nil {
-		fromMemcache, missing, err = c.memcache.FetchChunkData(userID, missing)
+	var fromCache []wire.Chunk
+	if c.chunkCache != nil {
+		fromCache, missing, err = c.chunkCache.FetchChunkData(userID, missing)
 		if err != nil {
 			log.Warnf("Error fetching from cache: %v", err)
 		}
@@ -368,15 +368,15 @@ func (c *AWSChunkStore) Get(ctx context.Context, from, through model.Time, match
 		return nil, err
 	}
 
-	if c.memcache != nil {
-		if err = c.memcache.StoreChunks(userID, fromS3); err != nil {
-			log.Warnf("Could not store chunks in memcache: %v", err)
+	if c.chunkCache != nil {
+		if err = c.chunkCache.StoreChunks(userID, fromS3); err != nil {
+			log.Warnf("Could not store chunks in chunk cache: %v", err)
 		}
 	}
 
 	// TODO instead of doing this sort, propagate an index and assign chunks
 	// into the result based on that index.
-	chunks := append(fromMemcache, fromS3...)
+	chunks := append(fromCache, fromS3...)
 	sort.Sort(wire.ChunksByID(chunks))
 	return chunks, nil
 }

--- a/frankenstein/chunk_store.go
+++ b/frankenstein/chunk_store.go
@@ -157,7 +157,6 @@ type AWSChunkStore struct {
 	chunkCache *ChunkCache
 	tableName  string
 	bucketName string
-	cfg        ChunkStoreConfig
 }
 
 type dynamodbClient interface {

--- a/frankenstein/chunk_store_test.go
+++ b/frankenstein/chunk_store_test.go
@@ -59,13 +59,13 @@ func TestChunkStore(t *testing.T) {
 	store := AWSChunkStore{
 		dynamodb:   mockaws.NewMockDynamoDB(),
 		s3:         mockaws.NewMockS3(),
-		memcache:   nil,
+		chunkCache: nil,
 		tableName:  "tablename",
 		bucketName: "bucketname",
 		cfg: ChunkStoreConfig{
-			S3URL:          "",
-			DynamoDBURL:    "",
-			MemcacheClient: nil,
+			S3URL:       "",
+			DynamoDBURL: "",
+			ChunkCache:  nil,
 		},
 	}
 	store.CreateTables()

--- a/frankenstein/chunk_store_test.go
+++ b/frankenstein/chunk_store_test.go
@@ -62,11 +62,6 @@ func TestChunkStore(t *testing.T) {
 		chunkCache: nil,
 		tableName:  "tablename",
 		bucketName: "bucketname",
-		cfg: ChunkStoreConfig{
-			S3URL:       "",
-			DynamoDBURL: "",
-			ChunkCache:  nil,
-		},
 	}
 	store.CreateTables()
 

--- a/frankenstein/cmd/frankenstein/main.go
+++ b/frankenstein/cmd/frankenstein/main.go
@@ -99,20 +99,22 @@ func main() {
 		log.Fatalf("Error initializing Consul client: %v", err)
 	}
 
-	var memcache *frankenstein.MemcacheClient
+	var chunkCache *frankenstein.ChunkCache
 	if memcachedHostname != "" {
-		memcache = frankenstein.NewMemcacheClient(frankenstein.MemcacheConfig{
-			Host:           memcachedHostname,
-			Service:        memcachedService,
-			Timeout:        memcachedTimeout,
-			UpdateInterval: 1 * time.Minute,
-			Expiration:     memcachedExpiration,
-		})
+		chunkCache = &frankenstein.ChunkCache{
+			Memcache: frankenstein.NewMemcacheClient(frankenstein.MemcacheConfig{
+				Host:           memcachedHostname,
+				Service:        memcachedService,
+				Timeout:        memcachedTimeout,
+				UpdateInterval: 1 * time.Minute,
+			}),
+			Expiration: memcachedExpiration,
+		}
 	}
 	chunkStore, err := frankenstein.NewAWSChunkStore(frankenstein.ChunkStoreConfig{
-		S3URL:          s3URL,
-		DynamoDBURL:    dynamodbURL,
-		MemcacheClient: memcache,
+		S3URL:       s3URL,
+		DynamoDBURL: dynamodbURL,
+		ChunkCache:  chunkCache,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/frankenstein/memcache_client.go
+++ b/frankenstein/memcache_client.go
@@ -21,44 +21,14 @@ import (
 	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
-	"github.com/prometheus/prometheus/frankenstein/wire"
 )
-
-var (
-	memcacheRequests = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: "prometheus",
-		Name:      "memcache_requests_total",
-		Help:      "Total count of chunks requested from memcache.",
-	})
-
-	memcacheHits = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: "prometheus",
-		Name:      "memcache_hits_total",
-		Help:      "Total count of chunks found in memcache.",
-	})
-
-	memcacheRequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "prometheus",
-		Name:      "memcache_request_duration_seconds",
-		Help:      "Total time spent in seconds doing memcache requests.",
-		Buckets:   []float64{.001, .0025, .005, .01, .025, .05},
-	}, []string{"method", "status_code"})
-)
-
-func init() {
-	prometheus.MustRegister(memcacheRequests)
-	prometheus.MustRegister(memcacheHits)
-	prometheus.MustRegister(memcacheRequestDuration)
-}
 
 // MemcacheClient is a memcache client that gets its server list from SRV
 // records, and periodically updates that ServerList.
 type MemcacheClient struct {
-	client     *memcache.Client
+	*memcache.Client
 	serverList *memcache.ServerList
-	expiration int32
 	hostname   string
 	service    string
 
@@ -72,7 +42,6 @@ type MemcacheConfig struct {
 	Service        string
 	Timeout        time.Duration
 	UpdateInterval time.Duration
-	Expiration     time.Duration
 }
 
 // NewMemcacheClient creates a new MemcacheClient that gets its server list
@@ -83,9 +52,8 @@ func NewMemcacheClient(config MemcacheConfig) *MemcacheClient {
 	client.Timeout = config.Timeout
 
 	newClient := &MemcacheClient{
-		client:     client,
+		Client:     client,
 		serverList: &servers,
-		expiration: int32(config.Expiration.Seconds()),
 		hostname:   config.Host,
 		service:    config.Service,
 		quit:       make(chan struct{}),
@@ -139,86 +107,4 @@ func (c *MemcacheClient) updateMemcacheServers() error {
 	// guarantee best possible match between nodes.
 	sort.Strings(servers)
 	return c.serverList.SetServers(servers...)
-}
-
-func memcacheStatusCode(err error) string {
-	// See https://godoc.org/github.com/bradfitz/gomemcache/memcache#pkg-variables
-	switch err {
-	case nil:
-		return "200"
-	case memcache.ErrCacheMiss:
-		return "404"
-	case memcache.ErrMalformedKey:
-		return "400"
-	default:
-		return "500"
-	}
-}
-
-func memcacheKey(userID, chunkID string) string {
-	return fmt.Sprintf("%s/%s", userID, chunkID)
-}
-
-// FetchChunkData gets chunks from memcache.
-func (c *MemcacheClient) FetchChunkData(userID string, chunks []wire.Chunk) (found []wire.Chunk, missing []wire.Chunk, err error) {
-	memcacheRequests.Add(float64(len(chunks)))
-
-	keys := make([]string, 0, len(chunks))
-	for _, chunk := range chunks {
-		keys = append(keys, memcacheKey(userID, chunk.ID))
-	}
-
-	var items map[string]*memcache.Item
-	err = timeRequestMethodStatus("Get", memcacheRequestDuration, memcacheStatusCode, func() error {
-		var err error
-		items, err = c.client.GetMulti(keys)
-		return err
-	})
-	if err != nil {
-		return nil, chunks, err
-	}
-
-	for _, chunk := range chunks {
-		item, ok := items[memcacheKey(userID, chunk.ID)]
-		if !ok {
-			missing = append(missing, chunk)
-		} else {
-			chunk.Data = item.Value
-			found = append(found, chunk)
-		}
-	}
-
-	memcacheHits.Add(float64(len(found)))
-	return found, missing, nil
-}
-
-// StoreChunkData serializes and stores a chunk in memcache.
-func (c *MemcacheClient) StoreChunkData(userID string, chunk *wire.Chunk) error {
-	return timeRequestMethodStatus("Put", memcacheRequestDuration, memcacheStatusCode, func() error {
-		// TODO: Add compression - maybe encapsulated in marshaling/unmarshaling
-		// methods of wire.Chunk.
-		item := memcache.Item{
-			Key:        memcacheKey(userID, chunk.ID),
-			Value:      chunk.Data,
-			Expiration: c.expiration,
-		}
-		return c.client.Set(&item)
-	})
-}
-
-// StoreChunks serializes and stores multiple chunks in memcache.
-func (c *MemcacheClient) StoreChunks(userID string, chunks []wire.Chunk) error {
-	errs := make(chan error)
-	for _, chunk := range chunks {
-		go func(chunk *wire.Chunk) {
-			errs <- c.StoreChunkData(userID, chunk)
-		}(&chunk)
-	}
-	var errOut error
-	for i := 0; i < len(chunks); i++ {
-		if err := <-errs; err != nil {
-			errOut = err
-		}
-	}
-	return errOut
 }


### PR DESCRIPTION
@tomwilkie Should we move the metric tracking to the generic memcache code? That way there's more we can reuse when backporting to Scope.
