### PR TITLE
Refactor ingester lifecycle code

### DIFF
--- a/frankenstein/consul_client.go
+++ b/frankenstein/consul_client.go
@@ -213,3 +213,34 @@ func (c *consulClient) PutBytes(key string, buf []byte) error {
 	}, &consul.WriteOptions{})
 	return err
 }
+
+type prefixedConsulClient struct {
+	prefix string
+	ConsulClient
+}
+
+// PrefixClient takes a ConsulClient and forces a prefix on all its operations.
+func PrefixClient(client ConsulClient, prefix string) ConsulClient {
+	return &prefixedConsulClient{prefix, client}
+}
+
+// Get and deserialise a JSON value from Consul.
+func (c *prefixedConsulClient) Get(key string, out interface{}) error {
+	return c.ConsulClient.Get(c.prefix+key, out)
+}
+
+// CAS atomically modifies a value in a callback. If the value doesn't exist,
+// you'll get 'nil' as an argument to your callback.
+func (c *prefixedConsulClient) CAS(key string, out interface{}, f CASCallback) error {
+	return c.ConsulClient.CAS(c.prefix+key, out, f)
+}
+
+// WatchPrefix watches a prefix. This is in addition to the prefix we already have.
+func (c *prefixedConsulClient) WatchPrefix(prefix string, factory func() interface{}, done chan struct{}, f func(string, interface{}) bool) {
+	c.ConsulClient.WatchPrefix(c.prefix+prefix, factory, done, f)
+}
+
+// PutBytes writes bytes to Consul.
+func (c *prefixedConsulClient) PutBytes(key string, buf []byte) error {
+	return c.ConsulClient.PutBytes(c.prefix+key, buf)
+}

--- a/frankenstein/consul_client.go
+++ b/frankenstein/consul_client.go
@@ -33,7 +33,7 @@ type ConsulClient interface {
 	Get(key string, out interface{}) error
 	CAS(key string, out interface{}, f CASCallback) error
 	WatchPrefix(prefix string, factory func() interface{}, done chan struct{}, f func(string, interface{}) bool)
-	Put(p *consul.KVPair, q *consul.WriteOptions) (*consul.WriteMeta, error)
+	PutBytes(key string, buf []byte) error
 }
 
 // CASCallback is the type of the callback to CAS.  If err is nil, out must be non-nil.
@@ -204,4 +204,12 @@ func (c *consulClient) WatchPrefix(prefix string, factory func() interface{}, do
 			}
 		}
 	}
+}
+
+func (c *consulClient) PutBytes(key string, buf []byte) error {
+	_, err := c.kv.Put(&consul.KVPair{
+		Key:   key,
+		Value: buf,
+	}, &consul.WriteOptions{})
+	return err
 }

--- a/frankenstein/consul_client.go
+++ b/frankenstein/consul_client.go
@@ -216,7 +216,7 @@ func (c *consulClient) PutBytes(key string, buf []byte) error {
 
 type prefixedConsulClient struct {
 	prefix string
-	ConsulClient
+	consul ConsulClient
 }
 
 // PrefixClient takes a ConsulClient and forces a prefix on all its operations.
@@ -226,21 +226,21 @@ func PrefixClient(client ConsulClient, prefix string) ConsulClient {
 
 // Get and deserialise a JSON value from Consul.
 func (c *prefixedConsulClient) Get(key string, out interface{}) error {
-	return c.ConsulClient.Get(c.prefix+key, out)
+	return c.consul.Get(c.prefix+key, out)
 }
 
 // CAS atomically modifies a value in a callback. If the value doesn't exist,
 // you'll get 'nil' as an argument to your callback.
 func (c *prefixedConsulClient) CAS(key string, out interface{}, f CASCallback) error {
-	return c.ConsulClient.CAS(c.prefix+key, out, f)
+	return c.consul.CAS(c.prefix+key, out, f)
 }
 
 // WatchPrefix watches a prefix. This is in addition to the prefix we already have.
 func (c *prefixedConsulClient) WatchPrefix(prefix string, factory func() interface{}, done chan struct{}, f func(string, interface{}) bool) {
-	c.ConsulClient.WatchPrefix(c.prefix+prefix, factory, done, f)
+	c.consul.WatchPrefix(c.prefix+prefix, factory, done, f)
 }
 
 // PutBytes writes bytes to Consul.
 func (c *prefixedConsulClient) PutBytes(key string, buf []byte) error {
-	return c.ConsulClient.PutBytes(c.prefix+key, buf)
+	return c.consul.PutBytes(c.prefix+key, buf)
 }

--- a/frankenstein/ingester_lifecycle.go
+++ b/frankenstein/ingester_lifecycle.go
@@ -29,12 +29,10 @@ func WriteIngesterConfigToConsul(consulClient ConsulClient, listenPort int, numT
 }
 
 func writeIngesterConfigToConsul(consulClient ConsulClient, desc *IngesterDesc) error {
-	log.Info("Adding ingester to consul")
 	buf, err := json.Marshal(desc)
 	if err != nil {
 		return err
 	}
-
 	return consulClient.PutBytes(desc.ID, buf)
 }
 
@@ -73,7 +71,6 @@ func generateTokens(id string, numTokens int) []uint32 {
 // DeleteIngesterConfigFromConsul deletes ingestor config from Consul
 func DeleteIngesterConfigFromConsul(consulClient ConsulClient) error {
 	log.Info("Removing ingester from consul")
-
 	hostname, err := os.Hostname()
 	if err != nil {
 		return err
@@ -82,8 +79,6 @@ func DeleteIngesterConfigFromConsul(consulClient ConsulClient) error {
 }
 
 func deleteIngesterConfigFromConsul(consulClient ConsulClient, id string) error {
-	log.Info("Removing ingester from consul")
-
 	buf, err := json.Marshal(IngesterDesc{
 		ID:       id,
 		Hostname: "",
@@ -92,7 +87,6 @@ func deleteIngesterConfigFromConsul(consulClient ConsulClient, id string) error 
 	if err != nil {
 		return err
 	}
-
 	return consulClient.PutBytes(id, buf)
 }
 

--- a/frankenstein/ingester_lifecycle.go
+++ b/frankenstein/ingester_lifecycle.go
@@ -1,0 +1,110 @@
+// Responsible for managing the ingester lifecycle.
+
+package frankenstein
+
+import (
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"math/rand"
+	"net"
+	"os"
+
+	consul "github.com/hashicorp/consul/api"
+	"github.com/prometheus/common/log"
+)
+
+const (
+	infName = "eth0"
+)
+
+// WriteIngesterConfigToConsul writes ingester config to Consul
+func WriteIngesterConfigToConsul(consulClient ConsulClient, consulPrefix string, listenPort int, numTokens int) error {
+	log.Info("Adding ingester to consul")
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		return err
+	}
+
+	addr, err := getFirstAddressOf(infName)
+	if err != nil {
+		return err
+	}
+
+	tokenHasher := fnv.New64()
+	tokenHasher.Write([]byte(hostname))
+	r := rand.New(rand.NewSource(int64(tokenHasher.Sum64())))
+
+	tokens := []uint32{}
+	for i := 0; i < numTokens; i++ {
+		tokens = append(tokens, r.Uint32())
+	}
+
+	buf, err := json.Marshal(IngesterDesc{
+		ID:       hostname,
+		Hostname: fmt.Sprintf("%s:%d", addr, listenPort),
+		Tokens:   tokens,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = consulClient.Put(&consul.KVPair{
+		Key:   consulPrefix + hostname,
+		Value: buf,
+	}, &consul.WriteOptions{})
+	return err
+}
+
+// DeleteIngesterConfigFromConsul deletes ingester config from Consul
+func DeleteIngesterConfigFromConsul(consulClient ConsulClient, consulPrefix string) error {
+	log.Info("Removing ingester from consul")
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		return err
+	}
+
+	buf, err := json.Marshal(IngesterDesc{
+		ID:       hostname,
+		Hostname: "",
+		Tokens:   []uint32{},
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = consulClient.Put(&consul.KVPair{
+		Key:   consulPrefix + hostname,
+		Value: buf,
+	}, &consul.WriteOptions{})
+	return err
+}
+
+// getFirstAddressOf returns the first IPv4 address of the supplied interface name.
+func getFirstAddressOf(name string) (string, error) {
+	inf, err := net.InterfaceByName(name)
+	if err != nil {
+		return "", err
+	}
+
+	addrs, err := inf.Addrs()
+	if err != nil {
+		return "", err
+	}
+	if len(addrs) <= 0 {
+		return "", fmt.Errorf("No address found for %s", name)
+	}
+
+	for _, addr := range addrs {
+		switch v := addr.(type) {
+		case *net.IPNet:
+			if ip := v.IP.To4(); ip != nil {
+				return v.IP.String(), nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("No address found for %s", name)
+}

--- a/frankenstein/ingester_lifecycle.go
+++ b/frankenstein/ingester_lifecycle.go
@@ -26,7 +26,11 @@ func WriteIngesterConfigToConsul(consulClient ConsulClient, consulPrefix string,
 	if err != nil {
 		return err
 	}
+	return writeIngesterConfigToConsul(consulClient, consulPrefix, desc)
+}
 
+func writeIngesterConfigToConsul(consulClient ConsulClient, consulPrefix string, desc *IngesterDesc) error {
+	log.Info("Adding ingester to consul")
 	buf, err := json.Marshal(desc)
 	if err != nil {
 		return err
@@ -79,9 +83,14 @@ func DeleteIngesterConfigFromConsul(consulClient ConsulClient, consulPrefix stri
 	if err != nil {
 		return err
 	}
+	return deleteIngesterConfigFromConsul(consulClient, consulPrefix, hostname)
+}
+
+func deleteIngesterConfigFromConsul(consulClient ConsulClient, consulPrefix string, id string) error {
+	log.Info("Removing ingester from consul")
 
 	buf, err := json.Marshal(IngesterDesc{
-		ID:       hostname,
+		ID:       id,
 		Hostname: "",
 		Tokens:   []uint32{},
 	})
@@ -90,7 +99,7 @@ func DeleteIngesterConfigFromConsul(consulClient ConsulClient, consulPrefix stri
 	}
 
 	_, err = consulClient.Put(&consul.KVPair{
-		Key:   consulPrefix + hostname,
+		Key:   consulPrefix + id,
 		Value: buf,
 	}, &consul.WriteOptions{})
 	return err

--- a/frankenstein/ingester_lifecycle.go
+++ b/frankenstein/ingester_lifecycle.go
@@ -1,3 +1,16 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Responsible for managing the ingester lifecycle.
 
 package frankenstein

--- a/frankenstein/ingester_lifecycle.go
+++ b/frankenstein/ingester_lifecycle.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"os"
 
-	consul "github.com/hashicorp/consul/api"
 	"github.com/prometheus/common/log"
 )
 
@@ -36,11 +35,7 @@ func writeIngesterConfigToConsul(consulClient ConsulClient, consulPrefix string,
 		return err
 	}
 
-	_, err = consulClient.Put(&consul.KVPair{
-		Key:   consulPrefix + desc.ID,
-		Value: buf,
-	}, &consul.WriteOptions{})
-	return err
+	return consulClient.PutBytes(consulPrefix+desc.ID, buf)
 }
 
 // describeLocalIngester returns an IngesterDesc for the ingester that is this
@@ -98,11 +93,7 @@ func deleteIngesterConfigFromConsul(consulClient ConsulClient, consulPrefix stri
 		return err
 	}
 
-	_, err = consulClient.Put(&consul.KVPair{
-		Key:   consulPrefix + id,
-		Value: buf,
-	}, &consul.WriteOptions{})
-	return err
+	return consulClient.PutBytes(consulPrefix+id, buf)
 }
 
 // getFirstAddressOf returns the first IPv4 address of the supplied interface name.

--- a/frankenstein/ingester_lifecycle.go
+++ b/frankenstein/ingester_lifecycle.go
@@ -18,24 +18,24 @@ const (
 )
 
 // WriteIngesterConfigToConsul writes ingester config to Consul
-func WriteIngesterConfigToConsul(consulClient ConsulClient, consulPrefix string, listenPort int, numTokens int) error {
+func WriteIngesterConfigToConsul(consulClient ConsulClient, listenPort int, numTokens int) error {
 	log.Info("Adding ingester to consul")
 
 	desc, err := describeLocalIngester(listenPort, numTokens)
 	if err != nil {
 		return err
 	}
-	return writeIngesterConfigToConsul(consulClient, consulPrefix, desc)
+	return writeIngesterConfigToConsul(consulClient, desc)
 }
 
-func writeIngesterConfigToConsul(consulClient ConsulClient, consulPrefix string, desc *IngesterDesc) error {
+func writeIngesterConfigToConsul(consulClient ConsulClient, desc *IngesterDesc) error {
 	log.Info("Adding ingester to consul")
 	buf, err := json.Marshal(desc)
 	if err != nil {
 		return err
 	}
 
-	return consulClient.PutBytes(consulPrefix+desc.ID, buf)
+	return consulClient.PutBytes(desc.ID, buf)
 }
 
 // describeLocalIngester returns an IngesterDesc for the ingester that is this
@@ -71,17 +71,17 @@ func generateTokens(id string, numTokens int) []uint32 {
 }
 
 // DeleteIngesterConfigFromConsul deletes ingestor config from Consul
-func DeleteIngesterConfigFromConsul(consulClient ConsulClient, consulPrefix string) error {
+func DeleteIngesterConfigFromConsul(consulClient ConsulClient) error {
 	log.Info("Removing ingester from consul")
 
 	hostname, err := os.Hostname()
 	if err != nil {
 		return err
 	}
-	return deleteIngesterConfigFromConsul(consulClient, consulPrefix, hostname)
+	return deleteIngesterConfigFromConsul(consulClient, hostname)
 }
 
-func deleteIngesterConfigFromConsul(consulClient ConsulClient, consulPrefix string, id string) error {
+func deleteIngesterConfigFromConsul(consulClient ConsulClient, id string) error {
 	log.Info("Removing ingester from consul")
 
 	buf, err := json.Marshal(IngesterDesc{
@@ -93,7 +93,7 @@ func deleteIngesterConfigFromConsul(consulClient ConsulClient, consulPrefix stri
 		return err
 	}
 
-	return consulClient.PutBytes(consulPrefix+id, buf)
+	return consulClient.PutBytes(id, buf)
 }
 
 // getFirstAddressOf returns the first IPv4 address of the supplied interface name.


### PR DESCRIPTION
Figuring out frankenstein code, and expressing my learning as refactoring:
- move lifecycle code to separate file (out of `main` package)
- add a `PutBytes` method to the `ConsulClient` interface
- add a new `ConsulClient` implementation that prefixes keys with a constant prefix
- split out "this is how we describe the ingester" logic from "this is how we register/unregister". The next (refactoring) step from here is an interface with `Register(desc IngesterDesc) error` and `Unregister(desc IngesterDesc) error` methods that hides consul.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomwilkie/prometheus/70)

<!-- Reviewable:end -->
