### PR TITLE
Allow ingester to start independently of Consul

### DIFF
--- a/frankenstein/cmd/frankenstein/main.go
+++ b/frankenstein/cmd/frankenstein/main.go
@@ -125,7 +125,7 @@ func main() {
 	case distributor:
 		setupDistributor(consul, chunkStore, remoteTimeout)
 	case ingester:
-		registerIngester(consul, listenPort, numTokens)
+		frankenstein.RegisterIngester(consul, listenPort, numTokens)
 		cfg := local.IngesterConfig{
 			FlushCheckPeriod: flushPeriod,
 			MaxChunkAge:      maxChunkAge,
@@ -199,19 +199,6 @@ func setupQuerier(
 
 	http.Handle(prefix+"/graph", frankenstein.GraphHandler())
 	http.Handle(prefix+"/static/", frankenstein.StaticAssetsHandler(prefix+"/static/"))
-}
-
-func registerIngester(consulClient frankenstein.ConsulClient, listenPort, numTokens int) error {
-	var err error
-	for i := 0; i < 10; i++ {
-		if err = frankenstein.WriteIngesterConfigToConsul(consulClient, listenPort, numTokens); err == nil {
-			break
-		} else {
-			log.Errorf("Failed to write to consul, sleeping: %v", err)
-			time.Sleep(1 * time.Second)
-		}
-	}
-	return err
 }
 
 func setupIngester(

--- a/frankenstein/ingester_lifecycle.go
+++ b/frankenstein/ingester_lifecycle.go
@@ -32,13 +32,8 @@ const (
 	infName = "eth0"
 )
 
-// IngesterRegistration is the registration of an ingester with a register.
-type IngesterRegistration interface {
-	Unregister() error
-}
-
 // IngesterRegistration manages the connection between the ingester and Consul.
-type ingesterRegistration struct {
+type IngesterRegistration struct {
 	consul ConsulClient
 	id     string
 	desc   []byte
@@ -48,7 +43,7 @@ type ingesterRegistration struct {
 }
 
 // RegisterIngester registers an ingester with Consul.
-func RegisterIngester(consulClient ConsulClient, listenPort, numTokens int) (IngesterRegistration, error) {
+func RegisterIngester(consulClient ConsulClient, listenPort, numTokens int) (*IngesterRegistration, error) {
 	desc, err := describeLocalIngester(listenPort, numTokens)
 	if err != nil {
 		return nil, err
@@ -58,7 +53,7 @@ func RegisterIngester(consulClient ConsulClient, listenPort, numTokens int) (Ing
 		return nil, err
 	}
 
-	r := &ingesterRegistration{
+	r := &IngesterRegistration{
 		consul: consulClient,
 		id:     desc.ID,
 		desc:   buf,
@@ -69,7 +64,7 @@ func RegisterIngester(consulClient ConsulClient, listenPort, numTokens int) (Ing
 	return r, nil
 }
 
-func (r *ingesterRegistration) updateLoop() error {
+func (r *IngesterRegistration) updateLoop() error {
 	defer r.wait.Done()
 	ticker := time.NewTicker(1 * time.Second)
 	for {
@@ -120,7 +115,7 @@ func generateTokens(id string, numTokens int) []uint32 {
 }
 
 // Unregister deletes ingestor config from Consul
-func (r *ingesterRegistration) Unregister() error {
+func (r *IngesterRegistration) Unregister() error {
 	log.Info("Removing ingester from consul")
 	buf, err := json.Marshal(IngesterDesc{
 		ID:       r.id,

--- a/frankenstein/ingester_lifecycle.go
+++ b/frankenstein/ingester_lifecycle.go
@@ -22,6 +22,7 @@ import (
 	"math/rand"
 	"net"
 	"os"
+	"time"
 
 	"github.com/prometheus/common/log"
 )
@@ -29,6 +30,20 @@ import (
 const (
 	infName = "eth0"
 )
+
+// RegisterIngester registers an ingester with Consul.
+func RegisterIngester(consulClient ConsulClient, listenPort, numTokens int) error {
+	var err error
+	for i := 0; i < 10; i++ {
+		if err = WriteIngesterConfigToConsul(consulClient, listenPort, numTokens); err == nil {
+			break
+		} else {
+			log.Errorf("Failed to write to consul, sleeping: %v", err)
+			time.Sleep(1 * time.Second)
+		}
+	}
+	return err
+}
 
 // WriteIngesterConfigToConsul writes ingester config to Consul
 func WriteIngesterConfigToConsul(consulClient ConsulClient, listenPort int, numTokens int) error {


### PR DESCRIPTION
Main behaviour change: ingester has a goroutine that loops until it can register itself with Consul.

Abstraction changes:
- separate registering the ingester completely from setting up the ingester—as the current implementations are completely independent
- new `IngesterRegistration` interface & a struct that implements that

I'm not a huge fan, tbh, but would welcome feedback.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tomwilkie/prometheus/71)

<!-- Reviewable:end -->
