### PR TITLE
Shard/parrallelise samples by fingerprint in StorageQueueManager, 

### DIFF
--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -44,7 +44,7 @@ type StorageClient interface {
 
 type StorageQueueManagerConfig struct {
 	QueueCapacity     int           // Number of samples to buffer per shard before we start dropping them.
-	Shards            int           // Number of shards, ie amount of concurrency.
+	Shards            int           // Number of shards, i.e. amount of concurrency.
 	MaxSamplesPerSend int           // Maximum number of samples per send.
 	BatchSendDeadline time.Duration // Maximum time sample will wait in buffer.
 }

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -43,10 +43,10 @@ type StorageClient interface {
 }
 
 type StorageQueueManagerConfig struct {
-	QueueCapacity     int           // number of samples to buffer per shard before we start dropping them
-	Shards            int           // number of shards, ie amount of concurrency
-	MaxSamplesPerSend int           // maximum number of samples per send
-	BatchSendDeadline time.Duration // maximum time sample will wait in buffer
+	QueueCapacity     int           // Number of samples to buffer per shard before we start dropping them.
+	Shards            int           // Number of shards, ie amount of concurrency.
+	MaxSamplesPerSend int           // Maximum number of samples per send.
+	BatchSendDeadline time.Duration // Maximum time sample will wait in buffer.
 }
 
 var defaultConfig = StorageQueueManagerConfig{

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -229,9 +229,11 @@ func (t *StorageQueueManager) runShard(i int) {
 		select {
 		case s, ok := <-shard:
 			if !ok {
-				log.Infof("Flushing %d samples to remote storage...", len(pendingSamples))
-				t.sendSamples(pendingSamples)
-				log.Infof("Done flushing.")
+				if len(pendingSamples) > 0 {
+					log.Infof("Flushing %d samples to remote storage...", len(pendingSamples))
+					t.sendSamples(pendingSamples)
+					log.Infof("Done flushing.")
+				}
 				return
 			}
 
@@ -242,8 +244,10 @@ func (t *StorageQueueManager) runShard(i int) {
 				pendingSamples = pendingSamples[t.cfg.MaxSamplesPerSend:]
 			}
 		case <-time.After(t.cfg.BatchSendDeadline):
-			t.sendSamples(pendingSamples)
-			pendingSamples = pendingSamples[:0]
+			if len(pendingSamples) > 0 {
+				t.sendSamples(pendingSamples)
+				pendingSamples = pendingSamples[:0]
+			}
 		}
 	}
 }

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -178,7 +178,7 @@ func (t *StorageQueueManager) Describe(ch chan<- *prometheus.Desc) {
 }
 
 // QueueLength returns the number of outstanding samples in the queue.
-func (t *StorageQueueManager) QueueLength() int {
+func (t *StorageQueueManager) queueLen() int {
 	queueLength := 0
 	for _, shard := range t.shards {
 		queueLength += len(shard)
@@ -190,7 +190,7 @@ func (t *StorageQueueManager) QueueLength() int {
 func (t *StorageQueueManager) Collect(ch chan<- prometheus.Metric) {
 	t.samplesCount.Collect(ch)
 	t.sendLatency.Collect(ch)
-	t.queueLength.Set(float64(t.QueueLength()))
+	t.queueLength.Set(float64(t.queueLen()))
 	ch <- t.failedBatches
 	ch <- t.failedSamples
 	ch <- t.queueLength

--- a/storage/remote/queue_manager.go
+++ b/storage/remote/queue_manager.go
@@ -14,21 +14,12 @@
 package remote
 
 import (
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/model"
-)
-
-const (
-	// The maximum number of concurrent send requests to the remote storage.
-	maxConcurrentSends = 10
-	// The maximum number of samples to fit into a single request to the remote storage.
-	maxSamplesPerSend = 100
-	// The deadline after which to send queued samples even if the maximum batch
-	// size has not been reached.
-	batchSendDeadline = 5 * time.Second
 )
 
 // String constants for instrumentation.
@@ -51,14 +42,28 @@ type StorageClient interface {
 	Name() string
 }
 
+type StorageQueueManagerConfig struct {
+	QueueCapacity     int           // number of samples to buffer per shard before we start dropping them
+	Shards            int           // number of shards, ie amount of concurrency
+	MaxSamplesPerSend int           // maximum number of samples per send
+	BatchSendDeadline time.Duration // maximum time sample will wait in buffer
+}
+
+var defaultConfig = StorageQueueManagerConfig{
+	QueueCapacity:     100 * 1024 / 10,
+	Shards:            10,
+	MaxSamplesPerSend: 100,
+	BatchSendDeadline: 5 * time.Second,
+}
+
 // StorageQueueManager manages a queue of samples to be sent to the Storage
 // indicated by the provided StorageClient.
 type StorageQueueManager struct {
-	tsdb           StorageClient
-	queue          chan *model.Sample
-	pendingSamples model.Samples
-	sendSemaphore  chan bool
-	drained        chan bool
+	cfg    StorageQueueManagerConfig
+	tsdb   StorageClient
+	shards []chan *model.Sample
+	wg     sync.WaitGroup
+	done   chan struct{}
 
 	samplesCount  *prometheus.CounterVec
 	sendLatency   prometheus.Summary
@@ -69,16 +74,21 @@ type StorageQueueManager struct {
 }
 
 // NewStorageQueueManager builds a new StorageQueueManager.
-func NewStorageQueueManager(tsdb StorageClient, queueCapacity int) *StorageQueueManager {
+func NewStorageQueueManager(tsdb StorageClient, cfg StorageQueueManagerConfig) *StorageQueueManager {
 	constLabels := prometheus.Labels{
 		"type": tsdb.Name(),
 	}
 
-	return &StorageQueueManager{
-		tsdb:          tsdb,
-		queue:         make(chan *model.Sample, queueCapacity),
-		sendSemaphore: make(chan bool, maxConcurrentSends),
-		drained:       make(chan bool),
+	shards := make([]chan *model.Sample, cfg.Shards)
+	for i := 0; i < cfg.Shards; i++ {
+		shards[i] = make(chan *model.Sample, cfg.QueueCapacity)
+	}
+
+	t := &StorageQueueManager{
+		cfg:    cfg,
+		tsdb:   tsdb,
+		shards: shards,
+		done:   make(chan struct{}),
 
 		samplesCount: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -126,17 +136,23 @@ func NewStorageQueueManager(tsdb StorageClient, queueCapacity int) *StorageQueue
 				constLabels,
 			),
 			prometheus.GaugeValue,
-			float64(queueCapacity),
+			float64(cfg.QueueCapacity),
 		),
 	}
+
+	t.wg.Add(cfg.Shards)
+	return t
 }
 
 // Append queues a sample to be sent to the remote storage. It drops the
 // sample on the floor if the queue is full.
 // Always returns nil.
 func (t *StorageQueueManager) Append(s *model.Sample) error {
+	fp := s.Metric.FastFingerprint()
+	shard := uint64(fp) % uint64(t.cfg.Shards)
+
 	select {
-	case t.queue <- s:
+	case t.shards[shard] <- s:
 	default:
 		t.samplesCount.WithLabelValues(dropped).Inc()
 		log.Warn("Remote storage queue full, discarding sample.")
@@ -144,16 +160,11 @@ func (t *StorageQueueManager) Append(s *model.Sample) error {
 	return nil
 }
 
-// Stop stops sending samples to the remote storage and waits for pending
-// sends to complete.
-func (t *StorageQueueManager) Stop() {
-	log.Infof("Stopping remote storage...")
-	close(t.queue)
-	<-t.drained
-	for i := 0; i < maxConcurrentSends; i++ {
-		t.sendSemaphore <- true
-	}
-	log.Info("Remote storage stopped.")
+// NeedsThrottling implements storage.SampleAppender. It will always return
+// false as a remote storage drops samples on the floor if backlogging instead
+// of asking for throttling.
+func (*StorageQueueManager) NeedsThrottling() bool {
+	return false
 }
 
 // Describe implements prometheus.Collector.
@@ -166,79 +177,92 @@ func (t *StorageQueueManager) Describe(ch chan<- *prometheus.Desc) {
 	ch <- t.queueCapacity.Desc()
 }
 
+// QueueLength returns the number of outstanding samples in the queue.
+func (t *StorageQueueManager) QueueLength() int {
+	queueLength := 0
+	for _, shard := range t.shards {
+		queueLength += len(shard)
+	}
+	return queueLength
+}
+
 // Collect implements prometheus.Collector.
 func (t *StorageQueueManager) Collect(ch chan<- prometheus.Metric) {
 	t.samplesCount.Collect(ch)
 	t.sendLatency.Collect(ch)
-	t.queueLength.Set(float64(len(t.queue)))
+	t.queueLength.Set(float64(t.QueueLength()))
 	ch <- t.failedBatches
 	ch <- t.failedSamples
 	ch <- t.queueLength
 	ch <- t.queueCapacity
 }
 
-func (t *StorageQueueManager) sendSamples(s model.Samples) {
-	t.sendSemaphore <- true
-
-	go func() {
-		defer func() {
-			<-t.sendSemaphore
-		}()
-
-		// Samples are sent to the remote storage on a best-effort basis. If a
-		// sample isn't sent correctly the first time, it's simply dropped on the
-		// floor.
-		begin := time.Now()
-		err := t.tsdb.Store(s)
-		duration := time.Since(begin).Seconds()
-
-		labelValue := success
-		if err != nil {
-			log.Warnf("error sending %d samples to remote storage: %s", len(s), err)
-			labelValue = failure
-			t.failedBatches.Inc()
-			t.failedSamples.Add(float64(len(s)))
-		}
-		t.samplesCount.WithLabelValues(labelValue).Add(float64(len(s)))
-		t.sendLatency.Observe(duration)
-	}()
-}
-
 // Run continuously sends samples to the remote storage.
 func (t *StorageQueueManager) Run() {
-	defer func() {
-		close(t.drained)
-	}()
+	for i := 0; i < t.cfg.Shards; i++ {
+		go t.runShard(i)
+	}
+	t.wg.Wait()
+}
 
-	// Send batches of at most maxSamplesPerSend samples to the remote storage.
+// Stop stops sending samples to the remote storage and waits for pending
+// sends to complete.
+func (t *StorageQueueManager) Stop() {
+	log.Infof("Stopping remote storage...")
+	for _, shard := range t.shards {
+		close(shard)
+	}
+	t.wg.Wait()
+	log.Info("Remote storage stopped.")
+}
+
+func (t *StorageQueueManager) runShard(i int) {
+	defer t.wg.Done()
+	shard := t.shards[i]
+
+	// Send batches of at most MaxSamplesPerSend samples to the remote storage.
 	// If we have fewer samples than that, flush them out after a deadline
 	// anyways.
+	pendingSamples := model.Samples{}
+
 	for {
 		select {
-		case s, ok := <-t.queue:
+		case s, ok := <-shard:
 			if !ok {
-				log.Infof("Flushing %d samples to remote storage...", len(t.pendingSamples))
-				t.flush()
+				log.Infof("Flushing %d samples to remote storage...", len(pendingSamples))
+				t.sendSamples(pendingSamples)
 				log.Infof("Done flushing.")
 				return
 			}
 
-			t.pendingSamples = append(t.pendingSamples, s)
+			pendingSamples = append(pendingSamples, s)
 
-			for len(t.pendingSamples) >= maxSamplesPerSend {
-				t.sendSamples(t.pendingSamples[:maxSamplesPerSend])
-				t.pendingSamples = t.pendingSamples[maxSamplesPerSend:]
+			for len(pendingSamples) >= t.cfg.MaxSamplesPerSend {
+				t.sendSamples(pendingSamples[:t.cfg.MaxSamplesPerSend])
+				pendingSamples = pendingSamples[t.cfg.MaxSamplesPerSend:]
 			}
-		case <-time.After(batchSendDeadline):
-			t.flush()
+		case <-time.After(t.cfg.BatchSendDeadline):
+			t.sendSamples(pendingSamples)
+			pendingSamples = pendingSamples[:0]
 		}
 	}
 }
 
-// Flush flushes remaining queued samples.
-func (t *StorageQueueManager) flush() {
-	if len(t.pendingSamples) > 0 {
-		t.sendSamples(t.pendingSamples)
+func (t *StorageQueueManager) sendSamples(s model.Samples) {
+	// Samples are sent to the remote storage on a best-effort basis. If a
+	// sample isn't sent correctly the first time, it's simply dropped on the
+	// floor.
+	begin := time.Now()
+	err := t.tsdb.Store(s)
+	duration := time.Since(begin).Seconds()
+
+	labelValue := success
+	if err != nil {
+		log.Warnf("error sending %d samples to remote storage: %s", len(s), err)
+		labelValue = failure
+		t.failedBatches.Inc()
+		t.failedSamples.Add(float64(len(s)))
 	}
-	t.pendingSamples = t.pendingSamples[:0]
+	t.samplesCount.WithLabelValues(labelValue).Add(float64(len(s)))
+	t.sendLatency.Observe(duration)
 }

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -22,28 +22,53 @@ import (
 )
 
 type TestStorageClient struct {
-	receivedSamples model.Samples
-	expectedSamples model.Samples
+	receivedSamples map[string]model.Samples
+	expectedSamples map[string]model.Samples
 	wg              sync.WaitGroup
+	mtx             sync.Mutex
 }
 
-func (c *TestStorageClient) expectSamples(s model.Samples) {
-	c.expectedSamples = append(c.expectedSamples, s...)
-	c.wg.Add(len(s))
+func NewTestStorageClient() *TestStorageClient {
+	return &TestStorageClient{
+		receivedSamples: map[string]model.Samples{},
+		expectedSamples: map[string]model.Samples{},
+	}
+}
+
+func (c *TestStorageClient) expectSamples(ss model.Samples) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	for _, s := range ss {
+		ts := s.Metric.String()
+		c.expectedSamples[ts] = append(c.expectedSamples[ts], s)
+	}
+	c.wg.Add(len(ss))
 }
 
 func (c *TestStorageClient) waitForExpectedSamples(t *testing.T) {
 	c.wg.Wait()
-	for i, expected := range c.expectedSamples {
-		if !expected.Equal(c.receivedSamples[i]) {
-			t.Fatalf("%d. Expected %v, got %v", i, expected, c.receivedSamples[i])
+
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	for ts, expectedSamples := range c.expectedSamples {
+		for i, expected := range expectedSamples {
+			if !expected.Equal(c.receivedSamples[ts][i]) {
+				t.Fatalf("%d. Expected %v, got %v", i, expected, c.receivedSamples[ts][i])
+			}
 		}
 	}
 }
 
-func (c *TestStorageClient) Store(s model.Samples) error {
-	c.receivedSamples = append(c.receivedSamples, s...)
-	c.wg.Add(-len(s))
+func (c *TestStorageClient) Store(ss model.Samples) error {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	for _, s := range ss {
+		ts := s.Metric.String()
+		c.receivedSamples[ts] = append(c.receivedSamples[ts], s)
+	}
+	c.wg.Add(-len(ss))
 	return nil
 }
 
@@ -96,7 +121,7 @@ func TestSampleDelivery(t *testing.T) {
 		})
 	}
 
-	c := &TestStorageClient{}
+	c := NewTestStorageClient()
 	c.expectSamples(samples[:len(samples)/2])
 	m := NewStorageQueueManager(c, cfg)
 
@@ -106,6 +131,39 @@ func TestSampleDelivery(t *testing.T) {
 	}
 	// These will be dropped because the queue is full.
 	for _, s := range samples[len(samples)/2:] {
+		m.Append(s)
+	}
+	go m.Run()
+	defer m.Stop()
+
+	c.waitForExpectedSamples(t)
+}
+
+func TestSampleDeliveryOrder(t *testing.T) {
+	cfg := defaultConfig
+	ts := 10
+	n := cfg.MaxSamplesPerSend * ts
+	// Ensure we don't drop samples in this test.
+	cfg.QueueCapacity = n
+
+	samples := make(model.Samples, 0, n)
+	for i := 0; i < n; i++ {
+		name := model.LabelValue(fmt.Sprintf("test_metric_%d", i%ts))
+		samples = append(samples, &model.Sample{
+			Metric: model.Metric{
+				model.MetricNameLabel: name,
+			},
+			Value:     model.SampleValue(i),
+			Timestamp: model.Time(i),
+		})
+	}
+
+	c := NewTestStorageClient()
+	c.expectSamples(samples)
+	m := NewStorageQueueManager(c, cfg)
+
+	// These should be received by the client.
+	for _, s := range samples {
 		m.Append(s)
 	}
 	go m.Run()

--- a/storage/remote/queue_manager_test.go
+++ b/storage/remote/queue_manager_test.go
@@ -203,7 +203,7 @@ func TestSpawnNotMoreThanMaxConcurrentSendsGoroutines(t *testing.T) {
 		c.getData <- true // Wait while all goroutines are spawned.
 	}
 
-	queueLength := m.QueueLength()
+	queueLength := m.queueLen()
 	if queueLength != cfg.MaxSamplesPerSend {
 		t.Errorf("Queue should contain %d samples, it contains %d.", cfg.MaxSamplesPerSend, queueLength)
 	}

--- a/storage/remote/remote.go
+++ b/storage/remote/remote.go
@@ -25,24 +25,15 @@ import (
 	influx "github.com/influxdb/influxdb/client"
 
 	"github.com/prometheus/prometheus/config"
-	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote/generic"
 	"github.com/prometheus/prometheus/storage/remote/graphite"
 	"github.com/prometheus/prometheus/storage/remote/influxdb"
 	"github.com/prometheus/prometheus/storage/remote/opentsdb"
 )
 
-type queue interface {
-	storage.SampleAppender
-	prometheus.Collector
-
-	Run()
-	Stop()
-}
-
 // Storage collects multiple remote storage queues.
 type Storage struct {
-	queues         []queue
+	queues         []*StorageQueueManager
 	externalLabels model.LabelSet
 	mtx            sync.RWMutex
 }


### PR DESCRIPTION
This will preserve the order of samples (within a given timeseries).

Fixes https://github.com/prometheus/prometheus/issues/1843

Merging here so we can test it, before opening another PR upstream.
