### PR TITLE
Remove fpMapper metrics from Prism ingester

### DIFF
--- a/storage/local/prism.go
+++ b/storage/local/prism.go
@@ -506,12 +506,6 @@ func (i *Ingester) flushChunks(ctx context.Context, fp model.Fingerprint, metric
 
 // Describe implements prometheus.Collector.
 func (i *Ingester) Describe(ch chan<- *prometheus.Desc) {
-	i.userStateLock.Lock()
-	for _, state := range i.userState {
-		state.mapper.Describe(ch)
-	}
-	i.userStateLock.Unlock()
-
 	ch <- memorySeriesDesc
 	ch <- memoryUsersDesc
 	ch <- i.ingestedSamples.Desc()
@@ -528,7 +522,6 @@ func (i *Ingester) Collect(ch chan<- prometheus.Metric) {
 	numUsers := len(i.userState)
 	numSeries := 0
 	for _, state := range i.userState {
-		state.mapper.Collect(ch)
 		numSeries += state.fpToSeries.length()
 	}
 	i.userStateLock.Unlock()


### PR DESCRIPTION
The problem is that the counter of mapped fingerprints does not have a
per-user label (which would be a bad idea), but we are Collect()-ing it
once for every user. This makes /metrics fail like this when an ingester
has data for more than one user:

```
An error has occurred during metrics collection:

collected metric prometheus_local_storage_fingerprint_mappings_total
counter:<value:0 >  was collected before with the same name and label
values
```

For now I'm just removing this one metric completely from the
collection, as it's relatively unimportant. One could think about
getting the value of each fpMapper's counter (only possible in a hacky
way with our metrics at the moment) and summing up all the counters in
the ingester. Or making one global metric out of it, but I didn't want
to modify the non-Prism Prometheus parts any further for now. Let's do
that when we copy over the remaining non-reusable parts of Prometheus
completely in the end.
