### PR TITLE
Don't log flushing

### DIFF
--- a/storage/local/prism.go
+++ b/storage/local/prism.go
@@ -465,7 +465,6 @@ func (i *Ingester) flushSeries(ctx context.Context, u *userState, fp model.Finge
 	}
 
 	// flush the chunks without locking the series
-	log.Infof("Flushing %d chunks", len(chunks))
 	if err := i.flushChunks(ctx, fp, series.metric, chunks); err != nil {
 		i.chunkStoreFailures.Add(float64(len(chunks)))
 		return err


### PR DESCRIPTION
We could add metrics, but we don't have evidence that we need them yet, and also this fork is soon to be replaced.

Helps with weaveworks/prism#36
